### PR TITLE
[chore] Bug/Task 이슈 템플릿 설정 추가 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,51 @@
+name: Bug Report
+description: 버그를 제보합니다
+title: '[bug] '
+labels:
+  - 🚨 bug - 오류 발생
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: 문제 요약
+      description: 어떤 문제가 발생했는지 간단히 적어주세요.
+      placeholder: 예) 마이페이지 프로젝트 목록이 비어 보임
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: 재현 방법
+      description: 재현 절차와 기대 결과/실제 결과를 함께 작성해주세요.
+      placeholder: |
+        - 절차:
+          1. 로그인
+          2. 마이페이지 이동
+          3. 필터 변경
+        - 기대 결과: 목록이 표시됨
+        - 실제 결과: 목록이 비어 있음
+    validations:
+      required: true
+
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: 재현 빈도
+      description: 어느 정도 자주 발생하는지 선택해주세요.
+      options:
+        - 항상 발생
+        - 가끔 발생
+        - 1회 발생
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: 실행 환경 및 참고 자료 (선택)
+      description: 디버깅에 도움이 되는 환경 정보와 참고 자료를 작성해주세요.
+      placeholder: |
+        - 로그/스크린샷:
+        - 브랜치/커밋:
+        - OS/브라우저:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,44 @@
+name: Task
+description: 기능 개발, 리팩터링, 문서화 등 작업 이슈를 등록합니다.
+title: '[task] '
+labels:
+  - 📋 task - 작업
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: 작업 목표
+      description: 무엇을 끝내려는 작업인지 한두 줄로 작성해주세요.
+      placeholder: 예) 마이페이지 필터 상태를 URL 쿼리와 동기화
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: 우선순위
+      description: 작업의 긴급도/중요도를 선택해주세요.
+      options:
+        - 높음
+        - 보통
+        - 낮음
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: 참고 자료 (선택)
+      description: 관련 이슈, 문서, PR 등 참고 링크를 남겨주세요.
+      placeholder: |
+        - 관련 이슈: #123
+        - 관련 문서: docs/CodeConvention.md
+
+  - type: textarea
+    id: subtasks
+    attributes:
+      label: 세부 작업 (선택)
+      description: 작업을 완료하기 위해 필요한 세부 작업 목록을 작성해주세요.
+      placeholder: |
+        - [ ] 세부 작업 1
+        - [ ] 세부 작업 2


### PR DESCRIPTION
## 개요 💡

GitHub에서 이슈 기반으로 작업을 관리하기 위해 이슈 템플릿을 추가했습니다.

## 작업내용 ⌨️

EveryGSM과 동일하게 작업했습니다.

- `.github/ISSUE_TEMPLATE/bug.yml `추가
- `.github/ISSUE_TEMPLATE/task.yml` 추가
- 버그 리포트와 일반 작업(task)을 구분하여 작성할 수 있도록 템플릿 구성


## 리뷰 요청사항 👀

추가로 라벨도 함께 추가했으니 확인 부탁드립니다.
