### PR TITLE
[feat] 어드민 메인 페이지와 학과 체험 신청 구현

### DIFF
--- a/src/app/admin/form/[id]/page.tsx
+++ b/src/app/admin/form/[id]/page.tsx
@@ -1,0 +1,19 @@
+import { notFound } from 'next/navigation';
+
+import { getActivityById } from '@/entities/activity';
+import { ActivityFormView } from '@/features/manageActivity';
+
+interface AdminFormEditPageProps {
+  params: Promise<{ id: string }>;
+}
+
+const AdminFormEditPage = async ({ params }: AdminFormEditPageProps) => {
+  const { id } = await params;
+  const activity = await getActivityById(Number(id));
+
+  if (!activity) notFound();
+
+  return <ActivityFormView mode="edit" activity={activity} />;
+};
+
+export default AdminFormEditPage;

--- a/src/app/admin/form/page.tsx
+++ b/src/app/admin/form/page.tsx
@@ -1,5 +1,11 @@
+import getActivityList from '@/entities/activity/api/getActivityList';
 import { ActivityFormView } from '@/features/manageActivity';
 
-const AdminFormPage = () => <ActivityFormView mode="create" />;
+const AdminFormPage = async () => {
+  const response = await getActivityList();
+  const isFirstActivity = !response?.data?.length;
+
+  return <ActivityFormView mode="create" isFirstActivity={isFirstActivity} />;
+};
 
 export default AdminFormPage;

--- a/src/app/admin/form/page.tsx
+++ b/src/app/admin/form/page.tsx
@@ -1,0 +1,5 @@
+import { ActivityFormView } from '@/features/manageActivity';
+
+const AdminFormPage = () => <ActivityFormView mode="create" />;
+
+export default AdminFormPage;

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,5 @@
+import { AdminPage } from '@/views/admin';
+
+const Admin = async () => <AdminPage />;
+
+export default Admin;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 
-import { TanStackProvider } from '@/shared/lib';
+import { cn, TanStackProvider } from '@/shared/lib';
 import { pretendard } from '@/shared/styles';
 import { Footer } from '@/widgets/footer';
 import { Header } from '@/widgets/header';
@@ -22,7 +22,7 @@ const RootLayout = ({
       <body className={pretendard.className}>
         <TanStackProvider>
           <Header />
-          {children}
+          <div className={cn('flex-1')}>{children}</div>
           <Footer />
         </TanStackProvider>
       </body>

--- a/src/entities/activity/api/getActivityList.ts
+++ b/src/entities/activity/api/getActivityList.ts
@@ -8,6 +8,7 @@ const getActivityList = async (): Promise<ActivityListResponseType | undefined> 
     endpoint: activityUrl.getActivityList(),
     context: 'getActivityList',
     errorMessage: '학과체험 목록 조회 실패:',
+    tags: ['activity-list'],
   });
 
 export default getActivityList;

--- a/src/entities/activity/api/revalidateActivityList.ts
+++ b/src/entities/activity/api/revalidateActivityList.ts
@@ -1,0 +1,7 @@
+'use server';
+
+import { revalidateTag } from 'next/cache';
+
+export const revalidateActivityList = async () => {
+  revalidateTag('activity-list', 'default');
+};

--- a/src/entities/activity/index.ts
+++ b/src/entities/activity/index.ts
@@ -3,3 +3,4 @@ export { default as getActivityList } from './api/getActivityList';
 export type { ActivityListResponseType, ActivityType } from './model/types';
 export { default as useGetActivityById } from './model/useGetActivityById';
 export { default as useGetActivityList } from './model/useGetActivityList';
+export { default as ActivityCard } from './ui/ActivityCard';

--- a/src/entities/activity/ui/ActivityCard.tsx
+++ b/src/entities/activity/ui/ActivityCard.tsx
@@ -1,0 +1,53 @@
+import { ReactNode } from 'react';
+
+import { cn } from '@/shared/lib';
+
+import type { ActivityType } from '../model/types';
+
+interface ActivityCardProps {
+  activity: ActivityType;
+  currentApplicant?: number;
+  actions?: ReactNode;
+  className?: string;
+}
+
+const ActivityCard = ({
+  activity,
+  currentApplicant = 0,
+  actions,
+  className,
+}: ActivityCardProps) => (
+  <section
+    className={cn(
+      'border-border-variant w-full rounded-lg border bg-white px-6 py-5 transition-colors duration-200',
+      className,
+    )}
+  >
+    <header className={cn('flex items-center justify-between')}>
+      <h2 className={cn('text-neutral-dark text-[1.5rem] leading-[1.2] font-semibold')}>
+        {activity.name}
+      </h2>
+      <p className={cn('text-neutral-dark text-[1.5rem] leading-[1.2] font-semibold')}>
+        {currentApplicant}/{activity.maxApplicant}
+      </p>
+    </header>
+
+    <ul
+      className={cn(
+        'text-secondary-slate mt-2 list-disc space-y-0.5 pl-5.25 text-[0.875rem] leading-[1.4] font-normal',
+      )}
+    >
+      {activity.description.split('\n').map((line, i) => (
+        <li key={i}>{line}</li>
+      ))}
+    </ul>
+
+    <p className={cn('text-secondary-slate mt-2 text-[0.875rem] leading-[1.4] font-normal')}>
+      {activity.activityDate}
+    </p>
+
+    {actions && <div className={cn('mt-4 flex justify-end gap-2')}>{actions}</div>}
+  </section>
+);
+
+export default ActivityCard;

--- a/src/features/adminUser/ui/DeleteUserModal.tsx
+++ b/src/features/adminUser/ui/DeleteUserModal.tsx
@@ -1,5 +1,7 @@
+'use client';
+
 import { useDeleteUser } from '@/features/adminUser/model/useDeleteUser';
-import { Button, Modal } from '@/shared/ui';
+import { ConfirmModal } from '@/shared/ui';
 
 interface DeleteUserModalProps {
   isOpen: boolean;
@@ -10,27 +12,15 @@ interface DeleteUserModalProps {
 const DeleteUserModal = ({ isOpen, onClose, userId }: DeleteUserModalProps) => {
   const { deleteUser, isPending } = useDeleteUser(userId);
 
-  const handleConfirm = () => {
-    deleteUser(undefined, { onSuccess: onClose });
-  };
-
   return (
-    <Modal isOpen={isOpen} onClose={isPending ? undefined : onClose} className="w-120 px-6 py-5">
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-col gap-2">
-          <h2 className="text-neutral-dark text-2xl font-semibold">신청자 정보 삭제</h2>
-          <p className="text-secondary-slate text-sm">정말 신청자 정보를 삭제하시겠습니까?</p>
-        </div>
-        <div className="flex justify-end gap-4">
-          <Button variant="outlineDanger" size="sm" onClick={onClose}>
-            취소
-          </Button>
-          <Button variant="danger" size="sm" disabled={isPending} onClick={handleConfirm}>
-            확인
-          </Button>
-        </div>
-      </div>
-    </Modal>
+    <ConfirmModal
+      isOpen={isOpen}
+      onClose={onClose}
+      onConfirm={() => deleteUser(undefined, { onSuccess: onClose })}
+      title="신청자 정보 삭제"
+      description="정말 신청자 정보를 삭제하시겠습니까?"
+      isPending={isPending}
+    />
   );
 };
 

--- a/src/features/auth/model/useLogin.ts
+++ b/src/features/auth/model/useLogin.ts
@@ -1,12 +1,18 @@
 import { getOAuthUrl } from '@/entities/auth';
 
 export const useLogin = () => {
+  const saveReturnUrl = () => {
+    sessionStorage.setItem('oauth_return_url', window.location.pathname);
+  };
+
   const handleGoogleLogin = () => {
+    saveReturnUrl();
     sessionStorage.setItem('oauth_provider', 'google');
     window.location.href = getOAuthUrl('google');
   };
 
   const handleKakaoLogin = () => {
+    saveReturnUrl();
     sessionStorage.setItem('oauth_provider', 'kakao');
     window.location.href = getOAuthUrl('kakao');
   };

--- a/src/features/auth/model/useOauthCallback.ts
+++ b/src/features/auth/model/useOauthCallback.ts
@@ -34,18 +34,26 @@ export const useOauthCallback = () => {
       {
         onSuccess: async () => {
           sessionStorage.removeItem('oauth_provider');
+          const returnUrl = sessionStorage.getItem('oauth_return_url') ?? '/';
+          sessionStorage.removeItem('oauth_return_url');
           try {
             const response = await queryClient.fetchQuery({
               queryKey: userQueryKeys.getMyInfo(),
               queryFn: () => get<ApiResponseType<UserType>>(userUrl.getMyInfo()),
             });
-            router.replace(checkIsAdmin(response.data.role) ? '/admin' : '/');
+            const isAdmin = checkIsAdmin(response.data.role);
+            if (isAdmin) {
+              router.replace('/admin');
+            } else {
+              router.replace(returnUrl === '/admin' ? '/' : returnUrl);
+            }
           } catch {
             router.replace('/');
           }
         },
         onError: () => {
           sessionStorage.removeItem('oauth_provider');
+          sessionStorage.removeItem('oauth_return_url');
           router.replace('/');
         },
       },

--- a/src/features/cancelApply/ui/CancelApplyModal.tsx
+++ b/src/features/cancelApply/ui/CancelApplyModal.tsx
@@ -1,5 +1,7 @@
+'use client';
+
 import { useCancelApply } from '@/features/cancelApply/model/useCancelApply';
-import { Button, Modal } from '@/shared/ui';
+import { ConfirmModal } from '@/shared/ui';
 
 interface CancelApplyModalProps {
   isOpen: boolean;
@@ -11,27 +13,15 @@ interface CancelApplyModalProps {
 const CancelApplyModal = ({ isOpen, onClose, userId, activityId }: CancelApplyModalProps) => {
   const { cancelApply, isPending } = useCancelApply(userId, activityId);
 
-  const handleConfirm = () => {
-    cancelApply(undefined, { onSuccess: onClose });
-  };
-
   return (
-    <Modal isOpen={isOpen} onClose={isPending ? undefined : onClose} className="w-120 px-6 py-5">
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-col gap-2">
-          <h2 className="text-neutral-dark text-2xl font-semibold">학과 체험 취소</h2>
-          <p className="text-secondary-slate text-sm">정말 학과 체험을 취소하시겠습니까?</p>
-        </div>
-        <div className="flex justify-end gap-2">
-          <Button variant="outlineDanger" size="sm" onClick={onClose}>
-            취소
-          </Button>
-          <Button variant="danger" size="sm" disabled={isPending} onClick={handleConfirm}>
-            확인
-          </Button>
-        </div>
-      </div>
-    </Modal>
+    <ConfirmModal
+      isOpen={isOpen}
+      onClose={onClose}
+      onConfirm={() => cancelApply(undefined, { onSuccess: onClose })}
+      title="학과 체험 취소"
+      description="정말 학과 체험을 취소하시겠습니까?"
+      isPending={isPending}
+    />
   );
 };
 

--- a/src/features/manageActivity/index.ts
+++ b/src/features/manageActivity/index.ts
@@ -1,4 +1,4 @@
-export type { ActivityFormType } from './model/types';
+export type { ActivityBaseFormType, ActivityFirstCreateFormType } from './model/types';
 export { useDeleteActivity } from './model/useDeleteActivity';
 export { usePatchActivity } from './model/usePatchActivity';
 export { usePostActivity } from './model/usePostActivity';

--- a/src/features/manageActivity/index.ts
+++ b/src/features/manageActivity/index.ts
@@ -1,0 +1,6 @@
+export type { ActivityFormType } from './model/types';
+export { useDeleteActivity } from './model/useDeleteActivity';
+export { usePatchActivity } from './model/usePatchActivity';
+export { usePostActivity } from './model/usePostActivity';
+export { default as ActivityFormView } from './ui/ActivityFormView';
+export { default as DeleteActivityModal } from './ui/DeleteActivityModal';

--- a/src/features/manageActivity/model/types.ts
+++ b/src/features/manageActivity/model/types.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+import type { ActivityType } from '@/entities/activity';
+
+export const ActivityFormSchema = z.object({
+  name: z.string().min(1, '학과 체험 이름을 입력해주세요').max(256),
+  place: z.string().min(1, '학과 체험 장소를 입력해주세요').max(200),
+  description: z.string().min(1, '학과 체험 설명을 입력해주세요').max(512),
+  maxApplicant: z.string().min(1, '최대 인원 수를 선택해주세요'),
+  registrationStartMonth: z.string().min(1, '월을 입력해주세요'),
+  registrationStartDay: z.string().min(1, '일을 입력해주세요'),
+  registrationEndMonth: z.string().min(1, '월을 입력해주세요'),
+  registrationEndDay: z.string().min(1, '일을 입력해주세요'),
+  activityYear: z.string().min(1, '년도를 선택해주세요'),
+  activityMonth: z.string().min(1, '월을 선택해주세요'),
+  activityDay: z.string().min(1, '일을 선택해주세요'),
+  activityStartHour: z.string().min(1, '시를 입력해주세요'),
+  activityStartMinute: z.string().min(1, '분을 입력해주세요'),
+  activityEndHour: z.string().min(1, '시를 입력해주세요'),
+  activityEndMinute: z.string().min(1, '분을 입력해주세요'),
+});
+
+export type ActivityFormType = z.infer<typeof ActivityFormSchema>;
+
+const pad = (n: string | number) => String(n).padStart(2, '0');
+
+export const toActivityReqDto = (values: ActivityFormType) => {
+  const currentYear = new Date().getFullYear();
+  return {
+    name: values.name,
+    place: values.place,
+    description: values.description,
+    maxApplicant: Number(values.maxApplicant),
+    activityDate: `${values.activityYear}-${pad(values.activityMonth)}-${pad(values.activityDay)}`,
+    registrationStartAt: `${currentYear}-${pad(values.registrationStartMonth)}-${pad(values.registrationStartDay)}T00:00:00`,
+    registrationEndAt: `${currentYear}-${pad(values.registrationEndMonth)}-${pad(values.registrationEndDay)}T23:59:59`,
+    activityStartTime: `${pad(values.activityStartHour)}:${pad(values.activityStartMinute)}`,
+    activityEndTime: `${pad(values.activityEndHour)}:${pad(values.activityEndMinute)}`,
+  };
+};
+
+export const toFormValues = (activity: ActivityType): ActivityFormType => {
+  const [regStartDate] = activity.registrationStartAt.split('T');
+  const [regEndDate] = activity.registrationEndAt.split('T');
+  const [, regStartMonth, regStartDay] = regStartDate.split('-');
+  const [, regEndMonth, regEndDay] = regEndDate.split('-');
+  const [actYear, actMonth, actDay] = activity.activityDate.split('-');
+  const [startHour, startMinute] = activity.activityStartTime.split(':');
+  const [endHour, endMinute] = activity.activityEndTime.split(':');
+
+  return {
+    name: activity.name,
+    place: activity.place,
+    description: activity.description,
+    maxApplicant: String(activity.maxApplicant),
+    registrationStartMonth: String(parseInt(regStartMonth, 10)),
+    registrationStartDay: String(parseInt(regStartDay, 10)),
+    registrationEndMonth: String(parseInt(regEndMonth, 10)),
+    registrationEndDay: String(parseInt(regEndDay, 10)),
+    activityYear: actYear,
+    activityMonth: String(parseInt(actMonth, 10)),
+    activityDay: String(parseInt(actDay, 10)),
+    activityStartHour: startHour,
+    activityStartMinute: startMinute,
+    activityEndHour: endHour,
+    activityEndMinute: endMinute,
+  };
+};

--- a/src/features/manageActivity/model/types.ts
+++ b/src/features/manageActivity/model/types.ts
@@ -2,15 +2,11 @@ import { z } from 'zod';
 
 import type { ActivityType } from '@/entities/activity';
 
-export const ActivityFormSchema = z.object({
+const baseActivityFields = {
   name: z.string().min(1, '학과 체험 이름을 입력해주세요').max(256),
   place: z.string().min(1, '학과 체험 장소를 입력해주세요').max(200),
   description: z.string().min(1, '학과 체험 설명을 입력해주세요').max(512),
   maxApplicant: z.string().min(1, '최대 인원 수를 선택해주세요'),
-  registrationStartMonth: z.string().min(1, '월을 입력해주세요'),
-  registrationStartDay: z.string().min(1, '일을 입력해주세요'),
-  registrationEndMonth: z.string().min(1, '월을 입력해주세요'),
-  registrationEndDay: z.string().min(1, '일을 입력해주세요'),
   activityYear: z.string().min(1, '년도를 선택해주세요'),
   activityMonth: z.string().min(1, '월을 선택해주세요'),
   activityDay: z.string().min(1, '일을 선택해주세요'),
@@ -18,32 +14,45 @@ export const ActivityFormSchema = z.object({
   activityStartMinute: z.string().min(1, '분을 입력해주세요'),
   activityEndHour: z.string().min(1, '시를 입력해주세요'),
   activityEndMinute: z.string().min(1, '분을 입력해주세요'),
+};
+
+export const ActivityBaseFormSchema = z.object(baseActivityFields);
+
+export const ActivityFirstCreateFormSchema = z.object({
+  ...baseActivityFields,
+  registrationStartMonth: z.string().min(1, '월을 입력해주세요'),
+  registrationStartDay: z.string().min(1, '일을 입력해주세요'),
+  registrationEndMonth: z.string().min(1, '월을 입력해주세요'),
+  registrationEndDay: z.string().min(1, '일을 입력해주세요'),
 });
 
-export type ActivityFormType = z.infer<typeof ActivityFormSchema>;
+export type ActivityBaseFormType = z.infer<typeof ActivityBaseFormSchema>;
+export type ActivityFirstCreateFormType = z.infer<typeof ActivityFirstCreateFormSchema>;
 
 const pad = (n: string | number) => String(n).padStart(2, '0');
 
-export const toActivityReqDto = (values: ActivityFormType) => {
+const toBaseFields = (values: ActivityBaseFormType) => ({
+  name: values.name,
+  place: values.place,
+  description: values.description,
+  maxApplicant: Number(values.maxApplicant),
+  activityDate: `${values.activityYear}-${pad(values.activityMonth)}-${pad(values.activityDay)}`,
+  activityStartTime: `${pad(values.activityStartHour)}:${pad(values.activityStartMinute)}`,
+  activityEndTime: `${pad(values.activityEndHour)}:${pad(values.activityEndMinute)}`,
+});
+
+export const toActivityBaseReqDto = (values: ActivityBaseFormType) => toBaseFields(values);
+
+export const toActivityFirstCreateReqDto = (values: ActivityFirstCreateFormType) => {
   const currentYear = new Date().getFullYear();
   return {
-    name: values.name,
-    place: values.place,
-    description: values.description,
-    maxApplicant: Number(values.maxApplicant),
-    activityDate: `${values.activityYear}-${pad(values.activityMonth)}-${pad(values.activityDay)}`,
+    ...toBaseFields(values),
     registrationStartAt: `${currentYear}-${pad(values.registrationStartMonth)}-${pad(values.registrationStartDay)}T00:00:00`,
     registrationEndAt: `${currentYear}-${pad(values.registrationEndMonth)}-${pad(values.registrationEndDay)}T23:59:59`,
-    activityStartTime: `${pad(values.activityStartHour)}:${pad(values.activityStartMinute)}`,
-    activityEndTime: `${pad(values.activityEndHour)}:${pad(values.activityEndMinute)}`,
   };
 };
 
-export const toFormValues = (activity: ActivityType): ActivityFormType => {
-  const [regStartDate] = activity.registrationStartAt.split('T');
-  const [regEndDate] = activity.registrationEndAt.split('T');
-  const [, regStartMonth, regStartDay] = regStartDate.split('-');
-  const [, regEndMonth, regEndDay] = regEndDate.split('-');
+export const toFormValues = (activity: ActivityType): ActivityBaseFormType => {
   const [actYear, actMonth, actDay] = activity.activityDate.split('-');
   const [startHour, startMinute] = activity.activityStartTime.split(':');
   const [endHour, endMinute] = activity.activityEndTime.split(':');
@@ -53,10 +62,6 @@ export const toFormValues = (activity: ActivityType): ActivityFormType => {
     place: activity.place,
     description: activity.description,
     maxApplicant: String(activity.maxApplicant),
-    registrationStartMonth: String(parseInt(regStartMonth, 10)),
-    registrationStartDay: String(parseInt(regStartDay, 10)),
-    registrationEndMonth: String(parseInt(regEndMonth, 10)),
-    registrationEndDay: String(parseInt(regEndDay, 10)),
     activityYear: actYear,
     activityMonth: String(parseInt(actMonth, 10)),
     activityDay: String(parseInt(actDay, 10)),

--- a/src/features/manageActivity/model/useDeleteActivity.ts
+++ b/src/features/manageActivity/model/useDeleteActivity.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { revalidateActivityList } from '@/entities/activity/api/revalidateActivityList';
+import { activityQueryKeys } from '@/entities/activity/model/useGetActivityList';
+import { activityUrl, del } from '@/shared/api';
+
+const useDeleteActivityMutation = (id: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => del(activityUrl.deleteActivity(id)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: activityQueryKeys.getActivityList() });
+      revalidateActivityList();
+    },
+  });
+};
+
+export const useDeleteActivity = (id: number) => {
+  const { mutate: deleteActivity, isPending } = useDeleteActivityMutation(id);
+  return { deleteActivity, isPending };
+};

--- a/src/features/manageActivity/model/usePatchActivity.ts
+++ b/src/features/manageActivity/model/usePatchActivity.ts
@@ -4,9 +4,9 @@ import { revalidateActivityList } from '@/entities/activity/api/revalidateActivi
 import { activityQueryKeys } from '@/entities/activity/model/useGetActivityList';
 import { activityUrl, patch } from '@/shared/api';
 
-import type { toActivityReqDto } from './types';
+import type { toActivityBaseReqDto } from './types';
 
-type ActivityReqDto = ReturnType<typeof toActivityReqDto>;
+type ActivityReqDto = ReturnType<typeof toActivityBaseReqDto>;
 
 const usePatchActivityMutation = (id: number) => {
   const queryClient = useQueryClient();

--- a/src/features/manageActivity/model/usePatchActivity.ts
+++ b/src/features/manageActivity/model/usePatchActivity.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { revalidateActivityList } from '@/entities/activity/api/revalidateActivityList';
+import { activityQueryKeys } from '@/entities/activity/model/useGetActivityList';
+import { activityUrl, patch } from '@/shared/api';
+
+import type { toActivityReqDto } from './types';
+
+type ActivityReqDto = ReturnType<typeof toActivityReqDto>;
+
+const usePatchActivityMutation = (id: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (dto: ActivityReqDto) => patch(activityUrl.patchActivity(id), dto),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: activityQueryKeys.getActivityList() });
+      revalidateActivityList();
+    },
+  });
+};
+
+export const usePatchActivity = (id: number) => {
+  const { mutate: patchActivity, isPending } = usePatchActivityMutation(id);
+  return { patchActivity, isPending };
+};

--- a/src/features/manageActivity/model/usePostActivity.ts
+++ b/src/features/manageActivity/model/usePostActivity.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { revalidateActivityList } from '@/entities/activity/api/revalidateActivityList';
+import { activityQueryKeys } from '@/entities/activity/model/useGetActivityList';
+import { activityUrl, post } from '@/shared/api';
+
+import type { toActivityReqDto } from './types';
+
+type ActivityReqDto = ReturnType<typeof toActivityReqDto>;
+
+const usePostActivityMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (dto: ActivityReqDto) => post(activityUrl.postActivity(), dto),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: activityQueryKeys.getActivityList() });
+      revalidateActivityList();
+    },
+  });
+};
+
+export const usePostActivity = () => {
+  const { mutate: postActivity, isPending } = usePostActivityMutation();
+  return { postActivity, isPending };
+};

--- a/src/features/manageActivity/model/usePostActivity.ts
+++ b/src/features/manageActivity/model/usePostActivity.ts
@@ -4,9 +4,11 @@ import { revalidateActivityList } from '@/entities/activity/api/revalidateActivi
 import { activityQueryKeys } from '@/entities/activity/model/useGetActivityList';
 import { activityUrl, post } from '@/shared/api';
 
-import type { toActivityReqDto } from './types';
+import type { toActivityBaseReqDto, toActivityFirstCreateReqDto } from './types';
 
-type ActivityReqDto = ReturnType<typeof toActivityReqDto>;
+type ActivityReqDto =
+  | ReturnType<typeof toActivityFirstCreateReqDto>
+  | ReturnType<typeof toActivityBaseReqDto>;
 
 const usePostActivityMutation = () => {
   const queryClient = useQueryClient();

--- a/src/features/manageActivity/ui/ActivityFormView.tsx
+++ b/src/features/manageActivity/ui/ActivityFormView.tsx
@@ -50,7 +50,8 @@ const ActivityFormView = ({ mode, activity }: ActivityFormViewProps) => {
     register,
     handleSubmit,
     control,
-    formState: { errors },
+    formState: { errors, isValid, isDirty },
+    trigger,
   } = useForm<ActivityFormType>({
     resolver: zodResolver(ActivityFormSchema),
     defaultValues: activity ? toFormValues(activity) : undefined,
@@ -297,15 +298,21 @@ const ActivityFormView = ({ mode, activity }: ActivityFormViewProps) => {
             </div>
           </FormField>
 
-          <Button
-            type="submit"
-            variant="default"
-            size="full"
-            disabled={isPending}
+          <div
             className={cn('mt-2')}
+            onClick={() => {
+              if (mode === 'create' && !isValid) trigger();
+            }}
           >
-            {mode === 'create' ? '학과 체험 만들기' : '학과 체험 수정하기'}
-          </Button>
+            <Button
+              type="submit"
+              variant="default"
+              size="full"
+              disabled={isPending || (mode === 'create' ? !isValid : !isDirty)}
+            >
+              {mode === 'create' ? '학과 체험 만들기' : '학과 체험 수정하기'}
+            </Button>
+          </div>
         </form>
       </div>
     </main>

--- a/src/features/manageActivity/ui/ActivityFormView.tsx
+++ b/src/features/manageActivity/ui/ActivityFormView.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ChevronLeft } from 'lucide-react';
+import { Controller, useForm } from 'react-hook-form';
+
+import type { ActivityType } from '@/entities/activity';
+import { cn } from '@/shared/lib';
+import {
+  Button,
+  FormField,
+  Input,
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/ui';
+
+import {
+  ActivityFormSchema,
+  type ActivityFormType,
+  toActivityReqDto,
+  toFormValues,
+} from '../model/types';
+import { usePatchActivity } from '../model/usePatchActivity';
+import { usePostActivity } from '../model/usePostActivity';
+
+interface ActivityFormViewProps {
+  mode: 'create' | 'edit';
+  activity?: ActivityType;
+}
+
+const CURRENT_YEAR = new Date().getFullYear();
+const YEARS = Array.from({ length: 5 }, (_, i) => CURRENT_YEAR + i - 1);
+const MONTHS = Array.from({ length: 12 }, (_, i) => i + 1);
+const DAYS = Array.from({ length: 31 }, (_, i) => i + 1);
+
+const ActivityFormView = ({ mode, activity }: ActivityFormViewProps) => {
+  const router = useRouter();
+  const { postActivity, isPending: isCreating } = usePostActivity();
+  const { patchActivity, isPending: isEditing } = usePatchActivity(activity?.id ?? 0);
+  const isPending = isCreating || isEditing;
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { errors },
+  } = useForm<ActivityFormType>({
+    resolver: zodResolver(ActivityFormSchema),
+    defaultValues: activity ? toFormValues(activity) : undefined,
+  });
+
+  const handleSuccess = () => {
+    router.push('/admin');
+    router.refresh();
+  };
+
+  const onSubmit = (values: ActivityFormType) => {
+    const dto = toActivityReqDto(values);
+    if (mode === 'create') {
+      postActivity(dto, { onSuccess: handleSuccess });
+    } else {
+      patchActivity(dto, { onSuccess: handleSuccess });
+    }
+  };
+
+  return (
+    <main
+      className={cn(
+        'flex min-h-[calc(100vh-6.25rem-11.3125rem)] flex-col items-center bg-white px-4 py-12',
+      )}
+    >
+      <div className={cn('flex w-full max-w-155.5 flex-col gap-6')}>
+        <button
+          type="button"
+          onClick={() => router.push('/admin')}
+          className={cn(
+            'text-secondary-slate flex w-fit cursor-pointer items-center gap-1 text-[1.25rem] font-semibold',
+          )}
+        >
+          <ChevronLeft className={cn('size-4')} />
+          이전으로
+        </button>
+
+        <h1 className={cn('text-neutral-dark text-[1.5rem] font-semibold')}>학과 체험 정보 작성</h1>
+
+        <form onSubmit={handleSubmit(onSubmit)} className={cn('flex flex-col gap-4')}>
+          <FormField label="학과 체험 이름" error={errors.name?.message}>
+            <Input
+              {...register('name')}
+              placeholder="학과 체험이름을 입력해주세요"
+              error={!!errors.name}
+            />
+          </FormField>
+
+          <FormField label="학과 체험 장소" error={errors.place?.message}>
+            <Input
+              {...register('place')}
+              placeholder="학과 체험 장소를 입력해주세요"
+              error={!!errors.place}
+            />
+          </FormField>
+
+          <FormField label="학과 체험 설명" error={errors.description?.message}>
+            <textarea
+              {...register('description')}
+              placeholder="학과 체험 설명을 입력해주세요"
+              rows={3}
+              className={cn(
+                'bg-pure-white text-neutral-dark placeholder:text-slate-utility min-w-0 resize-none rounded-[0.5rem] border px-3 py-2 text-sm leading-5 font-normal transition-colors outline-none',
+                errors.description
+                  ? 'border-error-red focus-visible:border-error-red'
+                  : 'border-border-variant hover:border-soft-gray focus-visible:border-brand-primary',
+              )}
+            />
+          </FormField>
+
+          <FormField label="최대 인원 수" error={errors.maxApplicant?.message}>
+            <Input
+              {...register('maxApplicant')}
+              type="number"
+              min={1}
+              placeholder="학과 체험 최대 인원 수를 입력해주세요"
+              error={!!errors.maxApplicant}
+            />
+          </FormField>
+
+          <FormField label="체험 접수 시작일">
+            <div className={cn('flex gap-2')}>
+              <Input
+                {...register('registrationStartMonth')}
+                placeholder="월을 입력해주세요"
+                type="number"
+                min={1}
+                max={12}
+                className={cn('flex-1')}
+                error={!!errors.registrationStartMonth}
+              />
+              <Input
+                {...register('registrationStartDay')}
+                placeholder="일을 입력해주세요"
+                type="number"
+                min={1}
+                max={31}
+                className={cn('flex-1')}
+                error={!!errors.registrationStartDay}
+              />
+            </div>
+          </FormField>
+
+          <FormField label="체험 접수 종료일">
+            <div className={cn('flex gap-2')}>
+              <Input
+                {...register('registrationEndMonth')}
+                placeholder="월을 입력해주세요"
+                type="number"
+                min={1}
+                max={12}
+                className={cn('flex-1')}
+                error={!!errors.registrationEndMonth}
+              />
+              <Input
+                {...register('registrationEndDay')}
+                placeholder="일을 입력해주세요"
+                type="number"
+                min={1}
+                max={31}
+                className={cn('flex-1')}
+                error={!!errors.registrationEndDay}
+              />
+            </div>
+          </FormField>
+
+          <FormField label="날짜">
+            <div className={cn('flex gap-2')}>
+              <Controller
+                name="activityYear"
+                control={control}
+                render={({ field }) => (
+                  <Select value={field.value ?? ''} onValueChange={field.onChange}>
+                    <SelectTrigger
+                      className={cn('flex-1', errors.activityYear && 'border-error-red')}
+                    >
+                      <SelectValue placeholder="년도 입력" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectLabel>날짜 선택</SelectLabel>
+                        {YEARS.map((y) => (
+                          <SelectItem key={y} value={String(y)}>
+                            {y}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+              <Controller
+                name="activityMonth"
+                control={control}
+                render={({ field }) => (
+                  <Select value={field.value ?? ''} onValueChange={field.onChange}>
+                    <SelectTrigger
+                      className={cn('flex-1', errors.activityMonth && 'border-error-red')}
+                    >
+                      <SelectValue placeholder="월 입력" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectLabel>날짜 선택</SelectLabel>
+                        {MONTHS.map((m) => (
+                          <SelectItem key={m} value={String(m)}>
+                            {m}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+              <Controller
+                name="activityDay"
+                control={control}
+                render={({ field }) => (
+                  <Select value={field.value ?? ''} onValueChange={field.onChange}>
+                    <SelectTrigger
+                      className={cn('flex-1', errors.activityDay && 'border-error-red')}
+                    >
+                      <SelectValue placeholder="일 입력" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectLabel>날짜 선택</SelectLabel>
+                        {DAYS.map((d) => (
+                          <SelectItem key={d} value={String(d)}>
+                            {d}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+          </FormField>
+
+          <FormField label="체험 시작 시간">
+            <div className={cn('flex gap-2')}>
+              <Input
+                {...register('activityStartHour')}
+                placeholder="시를 입력해주세요"
+                type="number"
+                min={0}
+                max={23}
+                className={cn('flex-1')}
+                error={!!errors.activityStartHour}
+              />
+              <Input
+                {...register('activityStartMinute')}
+                placeholder="분을 입력해주세요"
+                type="number"
+                min={0}
+                max={59}
+                className={cn('flex-1')}
+                error={!!errors.activityStartMinute}
+              />
+            </div>
+          </FormField>
+
+          <FormField label="체험 종료 시간">
+            <div className={cn('flex gap-2')}>
+              <Input
+                {...register('activityEndHour')}
+                placeholder="시를 입력해주세요"
+                type="number"
+                min={0}
+                max={23}
+                className={cn('flex-1')}
+                error={!!errors.activityEndHour}
+              />
+              <Input
+                {...register('activityEndMinute')}
+                placeholder="분을 입력해주세요"
+                type="number"
+                min={0}
+                max={59}
+                className={cn('flex-1')}
+                error={!!errors.activityEndMinute}
+              />
+            </div>
+          </FormField>
+
+          <Button
+            type="submit"
+            variant="default"
+            size="full"
+            disabled={isPending}
+            className={cn('mt-2')}
+          >
+            {mode === 'create' ? '학과 체험 만들기' : '학과 체험 수정하기'}
+          </Button>
+        </form>
+      </div>
+    </main>
+  );
+};
+
+export default ActivityFormView;

--- a/src/features/manageActivity/ui/ActivityFormView.tsx
+++ b/src/features/manageActivity/ui/ActivityFormView.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ChevronLeft } from 'lucide-react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, useForm, type UseFormReturn } from 'react-hook-form';
 
 import type { ActivityType } from '@/entities/activity';
 import { cn } from '@/shared/lib';
@@ -22,9 +22,12 @@ import {
 } from '@/shared/ui';
 
 import {
-  ActivityFormSchema,
-  type ActivityFormType,
-  toActivityReqDto,
+  ActivityBaseFormSchema,
+  type ActivityBaseFormType,
+  ActivityFirstCreateFormSchema,
+  type ActivityFirstCreateFormType,
+  toActivityBaseReqDto,
+  toActivityFirstCreateReqDto,
   toFormValues,
 } from '../model/types';
 import { usePatchActivity } from '../model/usePatchActivity';
@@ -33,6 +36,7 @@ import { usePostActivity } from '../model/usePostActivity';
 interface ActivityFormViewProps {
   mode: 'create' | 'edit';
   activity?: ActivityType;
+  isFirstActivity?: boolean;
 }
 
 const CURRENT_YEAR = new Date().getFullYear();
@@ -40,35 +44,207 @@ const YEARS = Array.from({ length: 5 }, (_, i) => CURRENT_YEAR + i - 1);
 const MONTHS = Array.from({ length: 12 }, (_, i) => i + 1);
 const DAYS = Array.from({ length: 31 }, (_, i) => i + 1);
 
-const ActivityFormView = ({ mode, activity }: ActivityFormViewProps) => {
+const ActivityFormView = ({ mode, activity, isFirstActivity }: ActivityFormViewProps) => {
   const router = useRouter();
   const { postActivity, isPending: isCreating } = usePostActivity();
   const { patchActivity, isPending: isEditing } = usePatchActivity(activity?.id ?? 0);
   const isPending = isCreating || isEditing;
 
-  const {
-    register,
-    handleSubmit,
-    control,
-    formState: { errors, isValid, isDirty },
-    trigger,
-  } = useForm<ActivityFormType>({
-    resolver: zodResolver(ActivityFormSchema),
+  const withRegistration = mode === 'create' && isFirstActivity;
+
+  const firstCreateForm = useForm<ActivityFirstCreateFormType>({
+    resolver: zodResolver(ActivityFirstCreateFormSchema),
+  });
+
+  const baseForm = useForm<ActivityBaseFormType>({
+    resolver: zodResolver(ActivityBaseFormSchema),
     defaultValues: activity ? toFormValues(activity) : undefined,
   });
+
+  const { isValid, isDirty } = (withRegistration ? firstCreateForm : baseForm).formState;
 
   const handleSuccess = () => {
     router.push('/admin');
     router.refresh();
   };
 
-  const onSubmit = (values: ActivityFormType) => {
-    const dto = toActivityReqDto(values);
+  const handleFirstCreateSubmit = (values: ActivityFirstCreateFormType) => {
+    postActivity(toActivityFirstCreateReqDto(values), { onSuccess: handleSuccess });
+  };
+
+  const handleBaseSubmit = (values: ActivityBaseFormType) => {
     if (mode === 'create') {
-      postActivity(dto, { onSuccess: handleSuccess });
+      postActivity(toActivityBaseReqDto(values), { onSuccess: handleSuccess });
     } else {
-      patchActivity(dto, { onSuccess: handleSuccess });
+      patchActivity(toActivityBaseReqDto(values), { onSuccess: handleSuccess });
     }
+  };
+
+  const renderBaseFields = (form: UseFormReturn<ActivityBaseFormType>) => {
+    const formErrors = form.formState.errors;
+    return (
+      <>
+        <FormField label="학과 체험 이름" error={formErrors.name?.message}>
+          <Input
+            {...form.register('name')}
+            placeholder="학과 체험이름을 입력해주세요"
+            error={!!formErrors.name}
+          />
+        </FormField>
+
+        <FormField label="학과 체험 장소" error={formErrors.place?.message}>
+          <Input
+            {...form.register('place')}
+            placeholder="학과 체험 장소를 입력해주세요"
+            error={!!formErrors.place}
+          />
+        </FormField>
+
+        <FormField label="학과 체험 설명" error={formErrors.description?.message}>
+          <textarea
+            {...form.register('description')}
+            placeholder="학과 체험 설명을 입력해주세요"
+            rows={3}
+            className={cn(
+              'bg-pure-white text-neutral-dark placeholder:text-slate-utility min-w-0 resize-none rounded-[0.5rem] border px-3 py-2 text-sm leading-5 font-normal transition-colors outline-none',
+              formErrors.description
+                ? 'border-error-red focus-visible:border-error-red'
+                : 'border-border-variant hover:border-soft-gray focus-visible:border-brand-primary',
+            )}
+          />
+        </FormField>
+
+        <FormField label="최대 인원 수" error={formErrors.maxApplicant?.message}>
+          <Input
+            {...form.register('maxApplicant')}
+            type="number"
+            min={1}
+            placeholder="학과 체험 최대 인원 수를 입력해주세요"
+            error={!!formErrors.maxApplicant}
+          />
+        </FormField>
+
+        <FormField label="날짜">
+          <div className={cn('flex gap-2')}>
+            <Controller
+              name="activityYear"
+              control={form.control}
+              render={({ field }) => (
+                <Select value={field.value ?? ''} onValueChange={field.onChange}>
+                  <SelectTrigger
+                    className={cn('flex-1', formErrors.activityYear && 'border-error-red')}
+                  >
+                    <SelectValue placeholder="년도 입력" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>날짜 선택</SelectLabel>
+                      {YEARS.map((y) => (
+                        <SelectItem key={y} value={String(y)}>
+                          {y}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            <Controller
+              name="activityMonth"
+              control={form.control}
+              render={({ field }) => (
+                <Select value={field.value ?? ''} onValueChange={field.onChange}>
+                  <SelectTrigger
+                    className={cn('flex-1', formErrors.activityMonth && 'border-error-red')}
+                  >
+                    <SelectValue placeholder="월 입력" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>날짜 선택</SelectLabel>
+                      {MONTHS.map((m) => (
+                        <SelectItem key={m} value={String(m)}>
+                          {m}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            <Controller
+              name="activityDay"
+              control={form.control}
+              render={({ field }) => (
+                <Select value={field.value ?? ''} onValueChange={field.onChange}>
+                  <SelectTrigger
+                    className={cn('flex-1', formErrors.activityDay && 'border-error-red')}
+                  >
+                    <SelectValue placeholder="일 입력" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>날짜 선택</SelectLabel>
+                      {DAYS.map((d) => (
+                        <SelectItem key={d} value={String(d)}>
+                          {d}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              )}
+            />
+          </div>
+        </FormField>
+
+        <FormField label="체험 시작 시간">
+          <div className={cn('flex gap-2')}>
+            <Input
+              {...form.register('activityStartHour')}
+              placeholder="시를 입력해주세요"
+              type="number"
+              min={0}
+              max={23}
+              className={cn('flex-1')}
+              error={!!formErrors.activityStartHour}
+            />
+            <Input
+              {...form.register('activityStartMinute')}
+              placeholder="분을 입력해주세요"
+              type="number"
+              min={0}
+              max={59}
+              className={cn('flex-1')}
+              error={!!formErrors.activityStartMinute}
+            />
+          </div>
+        </FormField>
+
+        <FormField label="체험 종료 시간">
+          <div className={cn('flex gap-2')}>
+            <Input
+              {...form.register('activityEndHour')}
+              placeholder="시를 입력해주세요"
+              type="number"
+              min={0}
+              max={23}
+              className={cn('flex-1')}
+              error={!!formErrors.activityEndHour}
+            />
+            <Input
+              {...form.register('activityEndMinute')}
+              placeholder="분을 입력해주세요"
+              type="number"
+              min={0}
+              max={59}
+              className={cn('flex-1')}
+              error={!!formErrors.activityEndMinute}
+            />
+          </div>
+        </FormField>
+      </>
+    );
   };
 
   return (
@@ -91,229 +267,100 @@ const ActivityFormView = ({ mode, activity }: ActivityFormViewProps) => {
 
         <h1 className={cn('text-neutral-dark text-[1.5rem] font-semibold')}>학과 체험 정보 작성</h1>
 
-        <form onSubmit={handleSubmit(onSubmit)} className={cn('flex flex-col gap-4')}>
-          <FormField label="학과 체험 이름" error={errors.name?.message}>
-            <Input
-              {...register('name')}
-              placeholder="학과 체험이름을 입력해주세요"
-              error={!!errors.name}
-            />
-          </FormField>
-
-          <FormField label="학과 체험 장소" error={errors.place?.message}>
-            <Input
-              {...register('place')}
-              placeholder="학과 체험 장소를 입력해주세요"
-              error={!!errors.place}
-            />
-          </FormField>
-
-          <FormField label="학과 체험 설명" error={errors.description?.message}>
-            <textarea
-              {...register('description')}
-              placeholder="학과 체험 설명을 입력해주세요"
-              rows={3}
-              className={cn(
-                'bg-pure-white text-neutral-dark placeholder:text-slate-utility min-w-0 resize-none rounded-[0.5rem] border px-3 py-2 text-sm leading-5 font-normal transition-colors outline-none',
-                errors.description
-                  ? 'border-error-red focus-visible:border-error-red'
-                  : 'border-border-variant hover:border-soft-gray focus-visible:border-brand-primary',
-              )}
-            />
-          </FormField>
-
-          <FormField label="최대 인원 수" error={errors.maxApplicant?.message}>
-            <Input
-              {...register('maxApplicant')}
-              type="number"
-              min={1}
-              placeholder="학과 체험 최대 인원 수를 입력해주세요"
-              error={!!errors.maxApplicant}
-            />
-          </FormField>
-
-          <FormField label="체험 접수 시작일">
-            <div className={cn('flex gap-2')}>
-              <Input
-                {...register('registrationStartMonth')}
-                placeholder="월을 입력해주세요"
-                type="number"
-                min={1}
-                max={12}
-                className={cn('flex-1')}
-                error={!!errors.registrationStartMonth}
-              />
-              <Input
-                {...register('registrationStartDay')}
-                placeholder="일을 입력해주세요"
-                type="number"
-                min={1}
-                max={31}
-                className={cn('flex-1')}
-                error={!!errors.registrationStartDay}
-              />
-            </div>
-          </FormField>
-
-          <FormField label="체험 접수 종료일">
-            <div className={cn('flex gap-2')}>
-              <Input
-                {...register('registrationEndMonth')}
-                placeholder="월을 입력해주세요"
-                type="number"
-                min={1}
-                max={12}
-                className={cn('flex-1')}
-                error={!!errors.registrationEndMonth}
-              />
-              <Input
-                {...register('registrationEndDay')}
-                placeholder="일을 입력해주세요"
-                type="number"
-                min={1}
-                max={31}
-                className={cn('flex-1')}
-                error={!!errors.registrationEndDay}
-              />
-            </div>
-          </FormField>
-
-          <FormField label="날짜">
-            <div className={cn('flex gap-2')}>
-              <Controller
-                name="activityYear"
-                control={control}
-                render={({ field }) => (
-                  <Select value={field.value ?? ''} onValueChange={field.onChange}>
-                    <SelectTrigger
-                      className={cn('flex-1', errors.activityYear && 'border-error-red')}
-                    >
-                      <SelectValue placeholder="년도 입력" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        <SelectLabel>날짜 선택</SelectLabel>
-                        {YEARS.map((y) => (
-                          <SelectItem key={y} value={String(y)}>
-                            {y}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                )}
-              />
-              <Controller
-                name="activityMonth"
-                control={control}
-                render={({ field }) => (
-                  <Select value={field.value ?? ''} onValueChange={field.onChange}>
-                    <SelectTrigger
-                      className={cn('flex-1', errors.activityMonth && 'border-error-red')}
-                    >
-                      <SelectValue placeholder="월 입력" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        <SelectLabel>날짜 선택</SelectLabel>
-                        {MONTHS.map((m) => (
-                          <SelectItem key={m} value={String(m)}>
-                            {m}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                )}
-              />
-              <Controller
-                name="activityDay"
-                control={control}
-                render={({ field }) => (
-                  <Select value={field.value ?? ''} onValueChange={field.onChange}>
-                    <SelectTrigger
-                      className={cn('flex-1', errors.activityDay && 'border-error-red')}
-                    >
-                      <SelectValue placeholder="일 입력" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        <SelectLabel>날짜 선택</SelectLabel>
-                        {DAYS.map((d) => (
-                          <SelectItem key={d} value={String(d)}>
-                            {d}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                )}
-              />
-            </div>
-          </FormField>
-
-          <FormField label="체험 시작 시간">
-            <div className={cn('flex gap-2')}>
-              <Input
-                {...register('activityStartHour')}
-                placeholder="시를 입력해주세요"
-                type="number"
-                min={0}
-                max={23}
-                className={cn('flex-1')}
-                error={!!errors.activityStartHour}
-              />
-              <Input
-                {...register('activityStartMinute')}
-                placeholder="분을 입력해주세요"
-                type="number"
-                min={0}
-                max={59}
-                className={cn('flex-1')}
-                error={!!errors.activityStartMinute}
-              />
-            </div>
-          </FormField>
-
-          <FormField label="체험 종료 시간">
-            <div className={cn('flex gap-2')}>
-              <Input
-                {...register('activityEndHour')}
-                placeholder="시를 입력해주세요"
-                type="number"
-                min={0}
-                max={23}
-                className={cn('flex-1')}
-                error={!!errors.activityEndHour}
-              />
-              <Input
-                {...register('activityEndMinute')}
-                placeholder="분을 입력해주세요"
-                type="number"
-                min={0}
-                max={59}
-                className={cn('flex-1')}
-                error={!!errors.activityEndMinute}
-              />
-            </div>
-          </FormField>
-
-          <div
-            className={cn('mt-2')}
-            onClick={() => {
-              if (mode === 'create' && !isValid) trigger();
-            }}
+        {withRegistration ? (
+          <form
+            onSubmit={firstCreateForm.handleSubmit(handleFirstCreateSubmit)}
+            className={cn('flex flex-col gap-4')}
           >
-            <Button
-              type="submit"
-              variant="default"
-              size="full"
-              disabled={isPending || (mode === 'create' ? !isValid : !isDirty)}
+            {renderBaseFields(firstCreateForm as unknown as UseFormReturn<ActivityBaseFormType>)}
+
+            <FormField
+              label="체험 접수 시작일"
+              error={firstCreateForm.formState.errors.registrationStartMonth?.message}
             >
-              {mode === 'create' ? '학과 체험 만들기' : '학과 체험 수정하기'}
-            </Button>
-          </div>
-        </form>
+              <div className={cn('flex gap-2')}>
+                <Input
+                  {...firstCreateForm.register('registrationStartMonth')}
+                  placeholder="월을 입력해주세요"
+                  type="number"
+                  min={1}
+                  max={12}
+                  className={cn('flex-1')}
+                  error={!!firstCreateForm.formState.errors.registrationStartMonth}
+                />
+                <Input
+                  {...firstCreateForm.register('registrationStartDay')}
+                  placeholder="일을 입력해주세요"
+                  type="number"
+                  min={1}
+                  max={31}
+                  className={cn('flex-1')}
+                  error={!!firstCreateForm.formState.errors.registrationStartDay}
+                />
+              </div>
+            </FormField>
+
+            <FormField
+              label="체험 접수 종료일"
+              error={firstCreateForm.formState.errors.registrationEndMonth?.message}
+            >
+              <div className={cn('flex gap-2')}>
+                <Input
+                  {...firstCreateForm.register('registrationEndMonth')}
+                  placeholder="월을 입력해주세요"
+                  type="number"
+                  min={1}
+                  max={12}
+                  className={cn('flex-1')}
+                  error={!!firstCreateForm.formState.errors.registrationEndMonth}
+                />
+                <Input
+                  {...firstCreateForm.register('registrationEndDay')}
+                  placeholder="일을 입력해주세요"
+                  type="number"
+                  min={1}
+                  max={31}
+                  className={cn('flex-1')}
+                  error={!!firstCreateForm.formState.errors.registrationEndDay}
+                />
+              </div>
+            </FormField>
+
+            <div
+              className={cn('mt-2')}
+              onClick={() => {
+                if (!isValid) firstCreateForm.trigger();
+              }}
+            >
+              <Button type="submit" variant="default" size="full" disabled={isPending || !isValid}>
+                학과 체험 만들기
+              </Button>
+            </div>
+          </form>
+        ) : (
+          <form
+            onSubmit={baseForm.handleSubmit(handleBaseSubmit)}
+            className={cn('flex flex-col gap-4')}
+          >
+            {renderBaseFields(baseForm)}
+
+            <div
+              className={cn('mt-2')}
+              onClick={() => {
+                if (mode === 'create' && !isValid) baseForm.trigger();
+              }}
+            >
+              <Button
+                type="submit"
+                variant="default"
+                size="full"
+                disabled={isPending || (mode === 'create' ? !isValid : !isDirty)}
+              >
+                {mode === 'create' ? '학과 체험 만들기' : '학과 체험 수정하기'}
+              </Button>
+            </div>
+          </form>
+        )}
       </div>
     </main>
   );

--- a/src/features/manageActivity/ui/DeleteActivityModal.tsx
+++ b/src/features/manageActivity/ui/DeleteActivityModal.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import type { ActivityType } from '@/entities/activity';
+import { cn } from '@/shared/lib';
+import { ConfirmModal } from '@/shared/ui';
+
+import { useDeleteActivity } from '../model/useDeleteActivity';
+
+interface DeleteActivityModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  activity: ActivityType;
+}
+
+const DeleteActivityModal = ({ isOpen, onClose, activity }: DeleteActivityModalProps) => {
+  const router = useRouter();
+  const { deleteActivity, isPending } = useDeleteActivity(activity.id);
+
+  const handleConfirm = () => {
+    deleteActivity(undefined, {
+      onSuccess: () => {
+        onClose();
+        router.refresh();
+      },
+    });
+  };
+
+  return (
+    <ConfirmModal
+      isOpen={isOpen}
+      onClose={onClose}
+      onConfirm={handleConfirm}
+      title="학과 체험 삭제"
+      description={
+        <>
+          <span className={cn('font-medium')}>{activity.name}</span>을(를) 삭제하시겠습니까?
+        </>
+      }
+      confirmText="삭제"
+      cancelVariant="outlinePrimary"
+      isPending={isPending}
+    />
+  );
+};
+
+export default DeleteActivityModal;

--- a/src/features/utility/index.ts
+++ b/src/features/utility/index.ts
@@ -1,1 +1,2 @@
+export { UserRoleFormSchema, type UserRoleFormType } from './model/types';
 export { usePatchUserRole } from './model/usePatchUserRole';

--- a/src/features/utility/model/types.ts
+++ b/src/features/utility/model/types.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+import type { UserRoleType } from '@/entities/user';
+
+export const UserRoleFormSchema = z.object({
+  email: z.string().email('유효한 이메일을 입력해주세요'),
+  role: z.enum(['USER', 'ADMIN', 'ROOT'] as [UserRoleType, ...UserRoleType[]]),
+});
+
+export type UserRoleFormType = z.infer<typeof UserRoleFormSchema>;

--- a/src/features/utility/model/usePatchUserRole.ts
+++ b/src/features/utility/model/usePatchUserRole.ts
@@ -1,19 +1,12 @@
 import { useMutation } from '@tanstack/react-query';
 
-import { UserRoleType } from '@/entities/user';
-import { ApiResponseType, patch, utilityUrl } from '@/shared/api';
+import { patch, utilityUrl } from '@/shared/api';
 
-interface PatchUserRoleParamsType {
-  email: string;
-  role: UserRoleType;
-}
+import type { UserRoleFormType } from './types';
 
 const usePatchUserRoleMutation = () =>
   useMutation({
-    mutationFn: ({ email, role }: PatchUserRoleParamsType) =>
-      patch<ApiResponseType<string>>(utilityUrl.patchUserRole(), undefined, {
-        params: { email, role },
-      }),
+    mutationFn: (dto: UserRoleFormType) => patch(utilityUrl.patchUserRole(), dto),
   });
 
 export const usePatchUserRole = () => {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const middleware = async (request: NextRequest) => {
+  try {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/v1/user/me`, {
+      headers: { Cookie: request.headers.get('cookie') ?? '' },
+      cache: 'no-store',
+    });
+
+    if (res.ok) {
+      const json = await res.json();
+      const role = json?.data?.role as string | undefined;
+      if (role === 'ADMIN' || role === 'ROOT') {
+        return NextResponse.next();
+      }
+    }
+  } catch {}
+
+  return NextResponse.rewrite(new URL('/not-found', request.url));
+};
+
+export const config = {
+  matcher: ['/admin', '/admin/:path*'],
+};

--- a/src/shared/api/apiUrls.ts
+++ b/src/shared/api/apiUrls.ts
@@ -14,6 +14,9 @@ export const utilityUrl = {
 export const activityUrl = {
   getActivityList: () => '/v1/activity',
   getActivityById: (id: number) => `/v1/activity/${id}`,
+  postActivity: () => '/v1/activity/admin',
+  patchActivity: (id: number) => `/v1/activity/admin/${id}`,
+  deleteActivity: (id: number) => `/v1/activity/admin/${id}`,
 } as const;
 
 export const applicationUrl = {

--- a/src/shared/api/fetcher.ts
+++ b/src/shared/api/fetcher.ts
@@ -2,16 +2,18 @@ interface ApiFetcherOptions {
   endpoint: string;
   context: string;
   errorMessage: string;
+  tags?: string[];
 }
 
 export const apiFetcher = async <T>({
   endpoint,
   context,
   errorMessage,
+  tags,
 }: ApiFetcherOptions): Promise<T | undefined> => {
   try {
     const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}${endpoint}`, {
-      next: { revalidate: 3600 },
+      next: { revalidate: 3600, tags },
     });
 
     if (!res.ok) throw new Error(`${res.status}`);

--- a/src/shared/ui/ConfirmModal.tsx
+++ b/src/shared/ui/ConfirmModal.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+import { cn } from '@/shared/lib';
+
+import { Button } from './button';
+import { Modal } from './Modal';
+
+interface ConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  description?: ReactNode;
+  confirmText?: string;
+  cancelText?: string;
+  confirmVariant?: 'danger' | 'default';
+  cancelVariant?: 'outlineDanger' | 'outlinePrimary';
+  isPending?: boolean;
+}
+
+const ConfirmModal = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  confirmText = '확인',
+  cancelText = '취소',
+  confirmVariant = 'danger',
+  cancelVariant = 'outlineDanger',
+  isPending = false,
+}: ConfirmModalProps) => (
+  <Modal isOpen={isOpen} onClose={isPending ? undefined : onClose} className="w-120 px-6 py-5">
+    <div className={cn('flex flex-col gap-6')}>
+      <div className={cn('flex flex-col gap-2')}>
+        <h2 className={cn('text-neutral-dark text-2xl font-semibold')}>{title}</h2>
+        {description && <p className={cn('text-secondary-slate text-sm')}>{description}</p>}
+      </div>
+      <div className={cn('flex justify-end gap-2')}>
+        <Button variant={cancelVariant} size="sm" onClick={onClose} disabled={isPending}>
+          {cancelText}
+        </Button>
+        <Button variant={confirmVariant} size="sm" onClick={onConfirm} disabled={isPending}>
+          {confirmText}
+        </Button>
+      </div>
+    </div>
+  </Modal>
+);
+
+export { ConfirmModal };

--- a/src/shared/ui/EmptyState.tsx
+++ b/src/shared/ui/EmptyState.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+
+import { cn } from '@/shared/lib';
+
+interface EmptyStateProps {
+  title: string;
+  description?: string;
+  children?: ReactNode;
+}
+
+const EmptyState = ({ title, description, children }: EmptyStateProps) => (
+  <main
+    className={cn(
+      'flex min-h-[calc(100vh-6.25rem-11.3125rem)] flex-col items-center justify-center gap-2 bg-white',
+    )}
+  >
+    <h1 className={cn('text-brand-primary text-[3rem] font-bold')}>{title}</h1>
+    {description && <p className={cn('text-secondary-slate text-[1.5rem]')}>{description}</p>}
+    {children}
+  </main>
+);
+
+export { EmptyState };

--- a/src/shared/ui/FormField.tsx
+++ b/src/shared/ui/FormField.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+import { cn } from '@/shared/lib';
+
+interface FormFieldProps {
+  label: string;
+  error?: string;
+  children: ReactNode;
+}
+
+const FormField = ({ label, error, children }: FormFieldProps) => (
+  <div className={cn('flex flex-col gap-1')}>
+    <label className={cn('text-neutral-dark text-sm font-medium')}>{label}</label>
+    {children}
+    {error && <p className={cn('text-error-red text-xs')}>{error}</p>}
+  </div>
+);
+
+export { FormField };

--- a/src/shared/ui/SectionHeader.tsx
+++ b/src/shared/ui/SectionHeader.tsx
@@ -1,0 +1,15 @@
+import { cn } from '@/shared/lib';
+
+interface SectionHeaderProps {
+  title: string;
+  description?: string;
+}
+
+const SectionHeader = ({ title, description }: SectionHeaderProps) => (
+  <div className={cn('flex flex-col gap-2')}>
+    <h1 className={cn('text-neutral-dark text-[1.5rem] font-semibold')}>{title}</h1>
+    {description && <p className={cn('text-secondary-slate text-[0.875rem]')}>{description}</p>}
+  </div>
+);
+
+export { SectionHeader };

--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/shared/lib';
 
 const buttonVariants = cva(
-  'inline-flex shrink-0 items-center justify-center whitespace-nowrap border text-sm leading-5 font-semibold transition-colors outline-none select-none disabled:cursor-not-allowed disabled:opacity-50',
+  'inline-flex shrink-0 items-center justify-center whitespace-nowrap border text-sm leading-5 font-semibold transition-colors outline-none select-none disabled:cursor-not-allowed disabled:pointer-events-none',
   {
     variants: {
       variant: {
@@ -39,11 +39,12 @@ function Button({
   ...props
 }: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
   const isDisabled = variant === 'neutral' || Boolean(disabled);
+  const effectiveVariant = isDisabled ? 'neutral' : variant;
 
   return (
     <ButtonPrimitive
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
+      className={cn(buttonVariants({ variant: effectiveVariant, size, className }))}
       disabled={isDisabled}
       {...props}
     />

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,6 +1,10 @@
 export { default as AnimateOnView } from './AnimateOnView';
 export * from './button';
 export { default as CompletionMessage } from './CompletionMessage';
+export * from './ConfirmModal';
+export * from './EmptyState';
+export * from './FormField';
 export * from './input';
 export * from './Modal';
+export * from './SectionHeader';
 export * from './select';

--- a/src/shared/ui/input.tsx
+++ b/src/shared/ui/input.tsx
@@ -14,7 +14,7 @@ function Input({ className, type, error = false, ...props }: InputProps) {
       type={type}
       data-slot="input"
       className={cn(
-        'bg-pure-white text-neutral-dark placeholder:text-slate-utility min-w-0 rounded-[0.5rem] border px-3 py-2 text-sm leading-5 font-normal transition-colors outline-none disabled:cursor-not-allowed disabled:opacity-50',
+        'bg-pure-white text-neutral-dark placeholder:text-slate-utility min-w-0 [appearance:textfield] rounded-[0.5rem] border px-3 py-2 text-sm leading-5 font-normal transition-colors outline-none disabled:cursor-not-allowed disabled:opacity-50 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none',
         error
           ? 'border-error-red focus-visible:border-error-red'
           : 'border-border-variant hover:border-soft-gray focus-visible:border-brand-primary',

--- a/src/views/admin/index.ts
+++ b/src/views/admin/index.ts
@@ -1,0 +1,1 @@
+export { default as AdminPage } from './ui/AdminPage';

--- a/src/views/admin/ui/AdminPage.tsx
+++ b/src/views/admin/ui/AdminPage.tsx
@@ -1,0 +1,10 @@
+import { getActivityList } from '@/entities/activity';
+import { AdminSection } from '@/widgets/adminSection';
+
+const AdminPage = async () => {
+  const activities = (await getActivityList())?.data ?? [];
+
+  return <AdminSection activities={activities} />;
+};
+
+export default AdminPage;

--- a/src/widgets/adminSection/index.ts
+++ b/src/widgets/adminSection/index.ts
@@ -1,0 +1,1 @@
+export { default as AdminSection } from './ui/AdminSection';

--- a/src/widgets/adminSection/ui/AdminSection.tsx
+++ b/src/widgets/adminSection/ui/AdminSection.tsx
@@ -33,6 +33,7 @@ const AdminSection = ({ activities }: AdminSectionProps) => {
             <ActivityCard
               key={activity.id}
               activity={activity}
+              currentApplicant={activity.currentApplicant}
               className={cn('min-h-44 hover:border-[#7C91A9]')}
               actions={
                 <>
@@ -62,7 +63,7 @@ const AdminSection = ({ activities }: AdminSectionProps) => {
               'border-border-variant flex min-h-44 w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border bg-white px-6 py-5 transition-colors duration-200 hover:border-[#7C91A9] hover:bg-[#EFF4FF]',
             )}
           >
-            <p className={cn('text-secondary-slate text-sm')}>프로젝트 등록</p>
+            <p className={cn('text-secondary-slate text-sm')}>학과체험 등록</p>
             <Plus className={cn('text-secondary-slate size-6')} />
           </button>
         </div>

--- a/src/widgets/adminSection/ui/AdminSection.tsx
+++ b/src/widgets/adminSection/ui/AdminSection.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { Plus } from 'lucide-react';
+
+import { ActivityCard, type ActivityType } from '@/entities/activity';
+import { DeleteActivityModal } from '@/features/manageActivity';
+import { cn } from '@/shared/lib';
+import { Button } from '@/shared/ui';
+
+interface AdminSectionProps {
+  activities: ActivityType[];
+}
+
+const AdminSection = ({ activities }: AdminSectionProps) => {
+  const router = useRouter();
+  const [deleteTarget, setDeleteTarget] = useState<ActivityType | null>(null);
+
+  return (
+    <main
+      className={cn(
+        'flex min-h-[calc(100vh-6.25rem-11.3125rem)] flex-col items-center bg-white px-4 py-12',
+      )}
+    >
+      <div className={cn('flex w-full max-w-155.5 flex-col gap-6')}>
+        <h1 className={cn('text-neutral-dark text-[1.5rem] font-semibold')}>학과 체험 추가</h1>
+
+        <div className={cn('flex flex-col gap-4')}>
+          {activities.map((activity) => (
+            <ActivityCard
+              key={activity.id}
+              activity={activity}
+              className={cn('min-h-44 hover:border-[#7C91A9]')}
+              actions={
+                <>
+                  <Button
+                    variant="outlineDanger"
+                    size="sm"
+                    onClick={() => setDeleteTarget(activity)}
+                  >
+                    학과 체험 삭제
+                  </Button>
+                  <Button
+                    variant="outlinePrimary"
+                    size="sm"
+                    onClick={() => router.push(`/admin/form/${activity.id}`)}
+                  >
+                    학과 체험 수정
+                  </Button>
+                </>
+              }
+            />
+          ))}
+
+          <button
+            type="button"
+            onClick={() => router.push('/admin/form')}
+            className={cn(
+              'border-border-variant flex min-h-44 w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border bg-white px-6 py-5 transition-colors duration-200 hover:border-[#7C91A9] hover:bg-[#EFF4FF]',
+            )}
+          >
+            <p className={cn('text-secondary-slate text-sm')}>프로젝트 등록</p>
+            <Plus className={cn('text-secondary-slate size-6')} />
+          </button>
+        </div>
+      </div>
+
+      {deleteTarget && (
+        <DeleteActivityModal
+          isOpen={!!deleteTarget}
+          onClose={() => setDeleteTarget(null)}
+          activity={deleteTarget}
+        />
+      )}
+    </main>
+  );
+};
+
+export default AdminSection;

--- a/src/widgets/applicationSection/ui/ApplicationSection.tsx
+++ b/src/widgets/applicationSection/ui/ApplicationSection.tsx
@@ -8,7 +8,7 @@ import { ProgramCard } from '@/entities/program';
 import { type UserType } from '@/entities/user';
 import { CancelApplyModal } from '@/features/cancelApply';
 import { cn } from '@/shared/lib';
-import { Button, CompletionMessage } from '@/shared/ui';
+import { Button, EmptyState, SectionHeader } from '@/shared/ui';
 
 interface ApplicationSectionProps {
   user: UserType | undefined;
@@ -21,7 +21,7 @@ const ApplicationSection = ({ user, application, activity }: ApplicationSectionP
 
   if (!user || user.role === 'UNAUTHENTICATED') {
     return (
-      <CompletionMessage
+      <EmptyState
         title="로그인이 필요한 기능입니다"
         description="학과 체험 신청 조회는 로그인이 필요한 기능입니다. 로그인 후 이용해주세요"
       />
@@ -30,10 +30,9 @@ const ApplicationSection = ({ user, application, activity }: ApplicationSectionP
 
   if (!application) {
     return (
-      <CompletionMessage
+      <EmptyState
         title="학과 체험을 아직 신청하지 않았습니다"
-        description="학과 체험을 아직 신청하지 않은 상태입니다. 학과 체험을 신청하거나 로그인된 계정을
-          확인해주세요."
+        description="학과 체험을 아직 신청하지 않은 상태입니다. 학과 체험을 신청하거나 로그인된 계정을 확인해주세요."
       />
     );
   }
@@ -47,14 +46,10 @@ const ApplicationSection = ({ user, application, activity }: ApplicationSectionP
       <div className={cn('flex w-full max-w-155.5 flex-col gap-9')}>
         {activity && (
           <section className={cn('flex flex-col gap-4')}>
-            <div className={cn('flex flex-col gap-2')}>
-              <h1 className={cn('text-neutral-dark text-[1.5rem] font-semibold')}>
-                신청한 학과 체험 정보
-              </h1>
-              <p className={cn('text-secondary-slate text-[0.875rem]')}>
-                로그인된 계정으로 신청된 학과 체험을 확인할 수 있습니다.
-              </p>
-            </div>
+            <SectionHeader
+              title="신청한 학과 체험 정보"
+              description="로그인된 계정으로 신청된 학과 체험을 확인할 수 있습니다."
+            />
             <ProgramCard
               name={activity.name}
               description={activity.description}
@@ -67,12 +62,10 @@ const ApplicationSection = ({ user, application, activity }: ApplicationSectionP
         )}
 
         <section className={cn('flex flex-col gap-4')}>
-          <div className={cn('flex flex-col gap-2')}>
-            <h1 className={cn('text-neutral-dark text-[1.5rem] font-semibold')}>신청자 정보</h1>
-            <p className={cn('text-secondary-slate text-[0.875rem]')}>
-              학과 체험을 신청한 사람의 정보를 불러옵니다.
-            </p>
-          </div>
+          <SectionHeader
+            title="신청자 정보"
+            description="학과 체험을 신청한 사람의 정보를 불러옵니다."
+          />
           <div className={cn('border-border-variant w-full rounded-lg border bg-white px-6 py-5')}>
             <div className={cn('grid grid-cols-2 gap-4')}>
               <dl className={cn('flex flex-col gap-4')}>

--- a/src/widgets/header/model/navigation.ts
+++ b/src/widgets/header/model/navigation.ts
@@ -7,7 +7,7 @@ export const NAV_LINKS = {
     { href: '/introduce', label: '더모먼트' },
   ],
   admin: [
-    { href: '/admin/form', label: '학과 체험' },
+    { href: '/admin', label: '학과 체험' },
     { href: '/admin/applicants', label: '신청자' },
   ],
 } as const;

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -25,8 +25,8 @@ const Header = () => {
   const { data: user } = useGetMyInfo();
   const { mutate: signOut } = usePostSignOut();
 
-  const isAdmin = pathname.startsWith('/admin');
   const isAdminRole = checkIsAdmin(user?.role);
+  const isAdmin = pathname.startsWith('/admin') && isAdminRole;
   const links = isAdmin ? NAV_LINKS.admin : NAV_LINKS.client;
 
   const handleSignOut = () => {


### PR DESCRIPTION
## 개요 💡
어드민 메인 페이지와 학과 체험 신청 기능을 구현했습니다.

## 작업내용 ⌨️
**어드민 학과체험 신청 및 관리**

- `/admin`, `/admin/form`, `/admin/form/{id}` 페이지 구현
- 학과체험 생성 · 수정 · 삭제 API 연동
- 미들웨어로 어드민 접근 권한 제어

**폼 UX**

- 필드 미입력 / 변경사항 없을 때 제출 버튼 비활성화
- 비활성화 버튼 클릭 시 유효성 검사 에러 표시

**기타**

- `ActivityType` 필드명 수정
- OAuth 로그인 후 원래 페이지 복귀 로직 추가
- 어드민 헤더 권한 체크 버그 수정

## 스크린샷/동영상 📸


https://github.com/user-attachments/assets/82129f79-fd73-4cb5-a1b4-732d5cc1c4b0



## 관련 이슈 🚨

https://github.com/themoment-team/readygsm-front/issues/31

