### PR TITLE
[feat] 토스트창 작업

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-hook-form": "^7.71.2",
+    "react-toastify": "^11.1.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       react-hook-form:
         specifier: ^7.71.2
         version: 7.71.2(react@19.2.4)
+      react-toastify:
+        specifier: ^11.1.0
+        version: 11.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -1950,6 +1953,12 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-toastify@11.1.0:
+    resolution: {integrity: sha512-e9h23x3phN0wbFeB6yovmWp7lobzV4CaCH0LO8nVP6H7Y+3GbcLpIzMm9dJhcp1RXbpyfvjgpfXqO80QAmn7sg==}
+    peerDependencies:
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -4130,6 +4139,12 @@ snapshots:
       react: 19.2.4
 
   react-is@16.13.1: {}
+
+  react-toastify@11.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      clsx: 2.1.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 
-import { cn, TanStackProvider } from '@/shared/lib';
+import { cn, TanStackProvider, ToastProvider } from '@/shared/lib';
 import { pretendard } from '@/shared/styles';
 import { Footer } from '@/widgets/footer';
 import { Header } from '@/widgets/header';
@@ -24,6 +24,7 @@ const RootLayout = ({
           <Header />
           <div className={cn('flex-1')}>{children}</div>
           <Footer />
+          <ToastProvider />
         </TanStackProvider>
       </body>
     </html>

--- a/src/features/adminUser/ui/DeleteUserModal.tsx
+++ b/src/features/adminUser/ui/DeleteUserModal.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { toast } from 'react-toastify';
+
 import { useDeleteUser } from '@/features/adminUser/model/useDeleteUser';
 import { ConfirmModal } from '@/shared/ui';
 
@@ -12,11 +14,21 @@ interface DeleteUserModalProps {
 const DeleteUserModal = ({ isOpen, onClose, userId }: DeleteUserModalProps) => {
   const { deleteUser, isPending } = useDeleteUser(userId);
 
+  const handleConfirm = () => {
+    deleteUser(undefined, {
+      onSuccess: () => {
+        toast.success('신청자 정보가 삭제되었습니다.');
+        onClose();
+      },
+      onError: () => toast.error('삭제 중 오류가 발생했습니다.'),
+    });
+  };
+
   return (
     <ConfirmModal
       isOpen={isOpen}
       onClose={onClose}
-      onConfirm={() => deleteUser(undefined, { onSuccess: onClose })}
+      onConfirm={handleConfirm}
       title="신청자 정보 삭제"
       description="정말 신청자 정보를 삭제하시겠습니까?"
       isPending={isPending}

--- a/src/features/applyDepartment/model/useApplicationForm.ts
+++ b/src/features/applyDepartment/model/useApplicationForm.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
+import { toast } from 'react-toastify';
 
 import { usePostApplication } from '@/entities/application';
 
@@ -42,7 +43,13 @@ export const useApplicationForm = (activityId: number, userId: number, onSuccess
         phoneNumber: data.phone,
         familyPhoneNumber: data.guardianPhone,
       },
-      { onSuccess },
+      {
+        onSuccess: () => {
+          toast.success('학과 체험 신청이 완료되었습니다.');
+          onSuccess?.();
+        },
+        onError: () => toast.error('신청 중 오류가 발생했습니다.'),
+      },
     );
   });
 

--- a/src/features/auth/model/useOauthCallback.ts
+++ b/src/features/auth/model/useOauthCallback.ts
@@ -5,6 +5,7 @@ import { useEffect, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
 
 import { getRedirectUri, type OAuthProviderType, usePostAuth } from '@/entities/auth';
 import { checkIsAdmin, userQueryKeys, type UserType } from '@/entities/user';
@@ -34,6 +35,7 @@ export const useOauthCallback = () => {
       {
         onSuccess: async () => {
           sessionStorage.removeItem('oauth_provider');
+          toast.success('로그인 되었습니다.');
           const returnUrl = sessionStorage.getItem('oauth_return_url') ?? '/';
           sessionStorage.removeItem('oauth_return_url');
           try {
@@ -54,6 +56,7 @@ export const useOauthCallback = () => {
         onError: () => {
           sessionStorage.removeItem('oauth_provider');
           sessionStorage.removeItem('oauth_return_url');
+          toast.error('로그인에 실패했습니다.');
           router.replace('/');
         },
       },

--- a/src/features/cancelApply/ui/CancelApplyModal.tsx
+++ b/src/features/cancelApply/ui/CancelApplyModal.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { toast } from 'react-toastify';
+
 import { useCancelApply } from '@/features/cancelApply/model/useCancelApply';
 import { ConfirmModal } from '@/shared/ui';
 
@@ -13,11 +15,21 @@ interface CancelApplyModalProps {
 const CancelApplyModal = ({ isOpen, onClose, userId, activityId }: CancelApplyModalProps) => {
   const { cancelApply, isPending } = useCancelApply(userId, activityId);
 
+  const handleConfirm = () => {
+    cancelApply(undefined, {
+      onSuccess: () => {
+        toast.success('학과 체험이 취소되었습니다.');
+        onClose();
+      },
+      onError: () => toast.error('취소 중 오류가 발생했습니다.'),
+    });
+  };
+
   return (
     <ConfirmModal
       isOpen={isOpen}
       onClose={onClose}
-      onConfirm={() => cancelApply(undefined, { onSuccess: onClose })}
+      onConfirm={handleConfirm}
       title="학과 체험 취소"
       description="정말 학과 체험을 취소하시겠습니까?"
       isPending={isPending}

--- a/src/shared/assets/index.ts
+++ b/src/shared/assets/index.ts
@@ -19,3 +19,5 @@ export {
   MergeIcon,
 } from './techIcon';
 export { default as TheMomentIcon } from './TheMomentIcon';
+export { default as CloseIcon } from './toast/CloseIcon';
+export { default as InfoIcon } from './toast/InfoIcon';

--- a/src/shared/assets/toast/CloseIcon.tsx
+++ b/src/shared/assets/toast/CloseIcon.tsx
@@ -1,0 +1,22 @@
+import { cn } from '@/shared/lib';
+
+const CloseIcon = () => (
+  <svg
+    width="1.5rem"
+    height="1.5rem"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={cn('Toastify__Close-Button')}
+  >
+    <path
+      d="M6 18L18 6M6 6L18 18"
+      stroke="#64748B"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default CloseIcon;

--- a/src/shared/assets/toast/InfoIcon.tsx
+++ b/src/shared/assets/toast/InfoIcon.tsx
@@ -1,0 +1,21 @@
+const InfoIcon = () => (
+  <svg
+    width="1.375rem"
+    height="1.375rem"
+    viewBox="0 0 22 22"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect width="22" height="22" rx="11" fill="#16A34A" />
+    <circle cx="10.25" cy="6.75" r="0.75" fill="#FDFDFD" stroke="#FDFDFD" />
+    <path
+      d="M9.5 10H11V16.5M11 16.5H9M11 16.5H13"
+      stroke="#FDFDFD"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default InfoIcon;

--- a/src/shared/assets/toast/InfoIcon.tsx
+++ b/src/shared/assets/toast/InfoIcon.tsx
@@ -1,4 +1,8 @@
-const InfoIcon = () => (
+interface InfoIconProps {
+  fill?: string;
+}
+
+const InfoIcon = ({ fill = '#16A34A' }: InfoIconProps) => (
   <svg
     width="1.375rem"
     height="1.375rem"
@@ -6,7 +10,7 @@ const InfoIcon = () => (
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <rect width="22" height="22" rx="11" fill="#16A34A" />
+    <rect width="22" height="22" rx="11" fill={fill} />
     <circle cx="10.25" cy="6.75" r="0.75" fill="#FDFDFD" stroke="#FDFDFD" />
     <path
       d="M9.5 10H11V16.5M11 16.5H9M11 16.5H13"

--- a/src/shared/assets/toast/toast.css
+++ b/src/shared/assets/toast/toast.css
@@ -1,0 +1,29 @@
+.Toastify__progress-bar--success {
+  background-color: #16a34a;
+}
+
+.Toastify__toast {
+  height: 5rem;
+  width: 21.6875rem;
+  right: 1.75rem;
+  top: 4rem;
+}
+
+.Toastify__toast-body {
+  font-size: 1rem;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 1.5rem;
+  color: #292e3d;
+}
+
+.Toastify__toast-icon {
+  margin-right: 1rem;
+  margin-left: 0.125rem;
+}
+
+.Toastify__Close-Button {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+}

--- a/src/shared/lib/ToastProvider.tsx
+++ b/src/shared/lib/ToastProvider.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { ToastContainer } from 'react-toastify';
+
+import { CloseIcon, InfoIcon } from '@/shared/assets';
+
+import '@/shared/assets/toast/toast.css';
+import 'react-toastify/dist/ReactToastify.css';
+
+const ToastProvider = () => (
+  <ToastContainer position="top-right" icon={<InfoIcon />} closeButton={<CloseIcon />} />
+);
+
+export default ToastProvider;

--- a/src/shared/lib/ToastProvider.tsx
+++ b/src/shared/lib/ToastProvider.tsx
@@ -7,8 +7,17 @@ import { CloseIcon, InfoIcon } from '@/shared/assets';
 import '@/shared/assets/toast/toast.css';
 import 'react-toastify/dist/ReactToastify.css';
 
+const ICON_FILL_BY_TYPE: Record<string, string> = {
+  error: '#F04636',
+  warning: '#D97706',
+};
+
 const ToastProvider = () => (
-  <ToastContainer position="top-right" icon={<InfoIcon />} closeButton={<CloseIcon />} />
+  <ToastContainer
+    position="top-right"
+    icon={({ type }) => <InfoIcon fill={ICON_FILL_BY_TYPE[type] ?? '#16A34A'} />}
+    closeButton={<CloseIcon />}
+  />
 );
 
 export default ToastProvider;

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -2,4 +2,5 @@ export * from './axios';
 export * from './cn';
 export * from './scroll';
 export { default as TanStackProvider } from './TanStackProvider';
+export { default as ToastProvider } from './ToastProvider';
 export { default as useDebounce } from './useDebounce';

--- a/src/shared/types/css.d.ts
+++ b/src/shared/types/css.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css' {
+  const styles: Record<string, string>;
+  export default styles;
+}

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 
 import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
 
 import { usePostSignOut } from '@/entities/auth';
 import { checkIsAdmin, useGetMyInfo, userQueryKeys } from '@/entities/user';
@@ -33,6 +34,7 @@ const Header = () => {
     signOut(undefined, {
       onSuccess: () => {
         queryClient.removeQueries({ queryKey: userQueryKeys.getMyInfo() });
+        toast.success('로그아웃 되었습니다.');
         router.replace('/');
       },
     });

--- a/src/widgets/introduceTeam/ui/TeamSection4.tsx
+++ b/src/widgets/introduceTeam/ui/TeamSection4.tsx
@@ -10,14 +10,14 @@ import { cn } from '@/shared/lib';
 const GITHUB_URL = 'https://github.com';
 
 const ALLOWED_IDS = new Set([
-  'seoxeon09',
+  's2yeons',
   'yeondon125',
   'junjuny0227',
   'h-0y28',
   'LeeSangHyeok0731',
   'snowykte0426',
   'wwwcomcomcomcom',
-  'ZaMan-O',
+  'ZaMan0806',
   'hongjm0912',
   'KIEYU5',
 ]);


### PR DESCRIPTION
## 개요 💡
사용자 액션에 대한 피드백을 제공하기 위해 react-toastify 기반 토스트 알림을 도입했습니다. 
디자인은 Hello, GSM 토스트창과 동일합니다.
## 작업내용 ⌨️

- `ToastProvider` 생성 및 루트 레이아웃에 등록
- 토스트 커스텀 스타일(toast.css) 및 아이콘(CloseIcon, InfoIcon) 추가
- 로그인 성공/실패, 로그아웃 성공 시 토스트 표시
- 학과 체험 취소 성공/실패 시 토스트 표시
- 신청자 정보 삭제 성공/실패 시 토스트 표시
- 그와 동시에 더모먼트 소개 페이지 TeamSection4 `ALLOWED_IDS`에서 변경된 팀원들 GitHub 아이디 수정

## 스크린샷/동영상 📸


https://github.com/user-attachments/assets/29038f05-6574-49c1-ad43-86e72b75b8c5



## 관련 이슈 🚨

https://github.com/themoment-team/readygsm-front/issues/46

