### PR TITLE
[feat] 신청자 관리 기능 구현

### DIFF
--- a/src/app/admin/applicants/page.tsx
+++ b/src/app/admin/applicants/page.tsx
@@ -1,0 +1,5 @@
+import { ApplicantManagementPage } from '@/views/admin';
+
+const ApplicantsPage = () => <ApplicantManagementPage />;
+
+export default ApplicantsPage;

--- a/src/entities/application/api/hooks.ts
+++ b/src/entities/application/api/hooks.ts
@@ -2,6 +2,16 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { type ApiResponseType, applicationUrl, del, get, post } from '@/shared/api';
 
+export const useDownloadApplicationExcel = () =>
+  useMutation({
+    mutationFn: async (activityId: number) => {
+      const response = await get<ApiResponseType<string>>(applicationUrl.getExcel(activityId));
+      const link = document.createElement('a');
+      link.href = response.data;
+      link.click();
+    },
+  });
+
 import type { ApplicationType, PostApplicationMutationInput } from '../model/types';
 
 export const applicationQueryKeys = {

--- a/src/entities/application/api/hooks.ts
+++ b/src/entities/application/api/hooks.ts
@@ -46,6 +46,8 @@ export const useDownloadApplicationExcel = () =>
       const response = await get<ApiResponseType<string>>(applicationUrl.getExcel(activityId));
       const link = document.createElement('a');
       link.href = response.data;
+      document.body.appendChild(link);
       link.click();
+      document.body.removeChild(link);
     },
   });

--- a/src/entities/application/api/hooks.ts
+++ b/src/entities/application/api/hooks.ts
@@ -1,21 +1,12 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
-import { type ApiResponseType, applicationUrl, del, get, post } from '@/shared/api';
-
-export const useDownloadApplicationExcel = () =>
-  useMutation({
-    mutationFn: async (activityId: number) => {
-      const response = await get<ApiResponseType<string>>(applicationUrl.getExcel(activityId));
-      const link = document.createElement('a');
-      link.href = response.data;
-      link.click();
-    },
-  });
+import { type ApiResponseType, applicationUrl, get, post } from '@/shared/api';
 
 import type { ApplicationType, PostApplicationMutationInput } from '../model/types';
 
 export const applicationQueryKeys = {
   getMyApplication: (userId: number) => ['application', 'my', userId] as const,
+  allAdminApplications: () => ['application', 'admin', 'list'] as const,
   getAllApplications: (activityId: number) =>
     ['application', 'admin', 'list', { activityId }] as const,
 } as const;
@@ -49,15 +40,12 @@ export const useGetAdminApplications = (activityId: number | null) =>
     enabled: activityId !== null,
   });
 
-export const useDeleteAdminApplication = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (id: number) => del<void>(applicationUrl.deleteApplication(id)),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['application', 'admin', 'list'],
-      });
+export const useDownloadApplicationExcel = () =>
+  useMutation({
+    mutationFn: async (activityId: number) => {
+      const response = await get<ApiResponseType<string>>(applicationUrl.getExcel(activityId));
+      const link = document.createElement('a');
+      link.href = response.data;
+      link.click();
     },
   });
-};

--- a/src/entities/application/api/hooks.ts
+++ b/src/entities/application/api/hooks.ts
@@ -43,11 +43,15 @@ export const useGetAdminApplications = (activityId: number | null) =>
 export const useDownloadApplicationExcel = () =>
   useMutation({
     mutationFn: async (activityId: number) => {
-      const response = await get<ApiResponseType<string>>(applicationUrl.getExcel(activityId));
+      const blob = await get<Blob>(applicationUrl.getExcel(activityId), { responseType: 'blob' });
+
+      const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
-      link.href = response.data;
+      link.href = url;
+      link.download = 'applications.xlsx';
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
+      URL.revokeObjectURL(url);
     },
   });

--- a/src/entities/application/api/hooks.ts
+++ b/src/entities/application/api/hooks.ts
@@ -1,11 +1,13 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { type ApiResponseType, applicationUrl, get, post } from '@/shared/api';
+import { type ApiResponseType, applicationUrl, del, get, post } from '@/shared/api';
 
 import type { ApplicationType, PostApplicationMutationInput } from '../model/types';
 
 export const applicationQueryKeys = {
   getMyApplication: (userId: number) => ['application', 'my', userId] as const,
+  getAllApplications: (activityId: number) =>
+    ['application', 'admin', 'list', { activityId }] as const,
 } as const;
 
 export const useGetMyApplication = (userId: number, enabled = true) =>
@@ -27,3 +29,25 @@ export const usePostApplication = () =>
         params: { userId, activityId },
       }),
   });
+
+export const useGetAdminApplications = (activityId: number | null) =>
+  useQuery({
+    queryKey: applicationQueryKeys.getAllApplications(activityId ?? 0),
+    queryFn: () =>
+      get<ApiResponseType<ApplicationType[]>>(applicationUrl.getAllApplications(activityId!)),
+    select: (res) => res.data,
+    enabled: activityId !== null,
+  });
+
+export const useDeleteAdminApplication = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => del<void>(applicationUrl.deleteApplication(id)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['application', 'admin', 'list'],
+      });
+    },
+  });
+};

--- a/src/features/manageApplicant/index.ts
+++ b/src/features/manageApplicant/index.ts
@@ -1,0 +1,1 @@
+export { useDeleteApplicant } from './model/useDeleteApplicant';

--- a/src/features/manageApplicant/model/useDeleteApplicant.ts
+++ b/src/features/manageApplicant/model/useDeleteApplicant.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { applicationQueryKeys } from '@/entities/application';
+import { applicationUrl, del } from '@/shared/api';
+
+export const useDeleteApplicant = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => del<void>(applicationUrl.deleteApplication(id)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: applicationQueryKeys.allAdminApplications(),
+      });
+    },
+  });
+};

--- a/src/shared/api/apiUrls.ts
+++ b/src/shared/api/apiUrls.ts
@@ -22,4 +22,7 @@ export const activityUrl = {
 export const applicationUrl = {
   getMyApplication: () => '/v1/application/my',
   postApplication: () => '/v1/application/apply',
+  getAllApplications: (id: number) => `/v1/application/admin/applications?activityId=${id}`,
+  deleteApplication: (id: number) => `/v1/application/admin/cancel/${id}`,
+  getExcel: (id: number) => `/v1/application/admin/excel?activityId=${id}`,
 } as const;

--- a/src/views/admin/index.ts
+++ b/src/views/admin/index.ts
@@ -1,1 +1,2 @@
 export { default as AdminPage } from './ui/AdminPage';
+export { default as ApplicantManagementPage } from './ui/ApplicantManagementPage';

--- a/src/views/admin/ui/ApplicantManagementPage.tsx
+++ b/src/views/admin/ui/ApplicantManagementPage.tsx
@@ -7,7 +7,7 @@ import { ApplicantManagementTable } from '@/widgets/applicantManagement';
 import { ApplicantManagementSidebar } from '@/widgets/applicantManagementSidebar';
 
 const ApplicantManagementPage = () => {
-  const [selectedActivityId, setSelectedActivityId] = useState<number | null>(null);
+  const [selectedActivityId, setSelectedActivityId] = useState<number | null>(1);
 
   return (
     <div className={cn('flex min-h-screen w-full px-[3rem]')}>
@@ -20,7 +20,7 @@ const ApplicantManagementPage = () => {
       </aside>
 
       {/* 본문 */}
-      <main className={cn('flex max-w-[80rem] flex-1 flex-col p-8')}>
+      <main className={cn('flex max-w-7xl flex-1 flex-col p-8')}>
         <ApplicantManagementTable activityId={selectedActivityId} />
       </main>
     </div>

--- a/src/views/admin/ui/ApplicantManagementPage.tsx
+++ b/src/views/admin/ui/ApplicantManagementPage.tsx
@@ -16,7 +16,7 @@ const ApplicantManagementPage = () => {
   const effectiveActivityId = selectedActivityId ?? minId;
 
   return (
-    <div className={cn('flex min-h-screen w-full px-[3rem]')}>
+    <div className={cn('flex min-h-screen w-full px-12')}>
       {/* 사이드바 */}
       <aside className={cn('w-55 shrink-0 px-4 py-10')}>
         <ApplicantManagementSidebar

--- a/src/views/admin/ui/ApplicantManagementPage.tsx
+++ b/src/views/admin/ui/ApplicantManagementPage.tsx
@@ -1,5 +1,30 @@
-import { ApplicantManagementTable } from '@/widgets/applicantManagement';
+'use client';
 
-const ApplicantManagementPage = () => <ApplicantManagementTable />;
+import { useState } from 'react';
+
+import { cn } from '@/shared/lib';
+import { ApplicantManagementTable } from '@/widgets/applicantManagement';
+import { ApplicantManagementSidebar } from '@/widgets/applicantManagementSidebar';
+
+const ApplicantManagementPage = () => {
+  const [selectedActivityId, setSelectedActivityId] = useState<number | null>(null);
+
+  return (
+    <div className={cn('flex min-h-screen w-full px-[3rem]')}>
+      {/* 사이드바 */}
+      <aside className={cn('w-55 shrink-0 px-4 py-10')}>
+        <ApplicantManagementSidebar
+          selectedActivityId={selectedActivityId}
+          onSelectActivity={setSelectedActivityId}
+        />
+      </aside>
+
+      {/* 본문 */}
+      <main className={cn('flex max-w-[80rem] flex-1 flex-col p-8')}>
+        <ApplicantManagementTable activityId={selectedActivityId} />
+      </main>
+    </div>
+  );
+};
 
 export default ApplicantManagementPage;

--- a/src/views/admin/ui/ApplicantManagementPage.tsx
+++ b/src/views/admin/ui/ApplicantManagementPage.tsx
@@ -2,26 +2,32 @@
 
 import { useState } from 'react';
 
+import { useGetActivityList } from '@/entities/activity';
 import { cn } from '@/shared/lib';
 import { ApplicantManagementTable } from '@/widgets/applicantManagement';
 import { ApplicantManagementSidebar } from '@/widgets/applicantManagementSidebar';
 
 const ApplicantManagementPage = () => {
-  const [selectedActivityId, setSelectedActivityId] = useState<number | null>(1);
+  const [selectedActivityId, setSelectedActivityId] = useState<number | null>(null);
+  const { data: activityList } = useGetActivityList();
+
+  const activities = activityList?.data ?? [];
+  const minId = activities.length > 0 ? Math.min(...activities.map((a) => a.id)) : null;
+  const effectiveActivityId = selectedActivityId ?? minId;
 
   return (
     <div className={cn('flex min-h-screen w-full px-[3rem]')}>
       {/* 사이드바 */}
       <aside className={cn('w-55 shrink-0 px-4 py-10')}>
         <ApplicantManagementSidebar
-          selectedActivityId={selectedActivityId}
+          selectedActivityId={effectiveActivityId}
           onSelectActivity={setSelectedActivityId}
         />
       </aside>
 
       {/* 본문 */}
       <main className={cn('flex max-w-7xl flex-1 flex-col p-8')}>
-        <ApplicantManagementTable activityId={selectedActivityId} />
+        <ApplicantManagementTable activityId={effectiveActivityId} />
       </main>
     </div>
   );

--- a/src/views/admin/ui/ApplicantManagementPage.tsx
+++ b/src/views/admin/ui/ApplicantManagementPage.tsx
@@ -1,0 +1,5 @@
+import { ApplicantManagementTable } from '@/widgets/applicantManagement';
+
+const ApplicantManagementPage = () => <ApplicantManagementTable />;
+
+export default ApplicantManagementPage;

--- a/src/widgets/applicantManagement/index.ts
+++ b/src/widgets/applicantManagement/index.ts
@@ -1,0 +1,1 @@
+export { default as ApplicantManagementTable } from './ui/ApplicantManagementTable';

--- a/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
+++ b/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import { useGetActivityList } from '@/entities/activity';
 import {
   type ApplicationType,
   useDownloadApplicationExcel,
@@ -24,6 +25,8 @@ const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps)
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
   const { data: applications = [] } = useGetAdminApplications(activityId);
+  const { data: activityList } = useGetActivityList();
+  const activities = activityList?.data ?? [];
   const { mutate: deleteApplication, isPending } = useDeleteApplicant();
   const { mutate: downloadExcel } = useDownloadApplicationExcel();
 
@@ -104,7 +107,7 @@ const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps)
                   )}
                 >
                   <span className={cn('text-neutral-dark text-center text-sm')}>
-                    {app.activityId}
+                    {activities.find((act) => act.id === app.activityId)?.name ?? app.activityId}
                   </span>
                 </div>
 

--- a/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
+++ b/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
@@ -59,7 +59,7 @@ const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps)
       </div>
 
       {isEmpty ? (
-        <div className={cn('flex min-h-[480px] w-full flex-1 items-center justify-center')}>
+        <div className={cn('flex min-h-120 w-full flex-1 items-center justify-center')}>
           <p
             className={cn(
               'text-center text-xl font-semibold tracking-[-0.0375rem] whitespace-nowrap text-[#656e82]',
@@ -70,7 +70,7 @@ const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps)
         </div>
       ) : (
         <div className={cn('overflow-x-auto rounded-lg border border-[#e4e4e7] bg-white')}>
-          <div className={cn('min-w-[800px]')}>
+          <div className={cn('min-w-200')}>
             {/* 테이블 헤더 */}
             <div className={cn('flex items-stretch border-b border-[#e4e4e7]')}>
               {TABLE_HEADERS.map((header, index) => (

--- a/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
+++ b/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useState } from 'react';
+
+import {
+  type AdminApplicationType,
+  useDeleteAdminApplication,
+  useGetAdminApplications,
+} from '@/entities/application';
+import { cn } from '@/shared/lib';
+import { Button, ConfirmModal } from '@/shared/ui';
+
+const TABLE_HEADERS = ['신청한 학과 체험', '이름', '전화번호', '학교명', '학번', ''];
+
+const formatStudentId = ({ grade, classNumber, number }: AdminApplicationType) =>
+  `${grade}${classNumber}${number.toString().padStart(2, '0')}`;
+
+const downloadCsv = (applications: AdminApplicationType[]) => {
+  const headers = ['신청한 학과 체험', '이름', '전화번호', '학교명', '학번'];
+  const rows = applications.map((app) => [
+    app.activityName,
+    app.name,
+    app.phoneNumber,
+    app.schoolName,
+    formatStudentId(app),
+  ]);
+
+  const csvContent = [headers, ...rows]
+    .map((row) => row.map((cell) => `"${cell}"`).join(','))
+    .join('\n');
+
+  const blob = new Blob(['﻿' + csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = '신청자_목록.csv';
+  link.click();
+  URL.revokeObjectURL(url);
+};
+
+const ApplicantManagementTable = () => {
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  const { data: applications = [] } = useGetAdminApplications();
+  const { mutate: deleteApplication, isPending } = useDeleteAdminApplication();
+
+  const handleDeleteClick = (id: number) => setSelectedId(id);
+  const handleCloseModal = () => setSelectedId(null);
+  const handleConfirmDelete = () => {
+    if (selectedId === null) return;
+    deleteApplication(selectedId, { onSuccess: handleCloseModal });
+  };
+
+  const isEmpty = applications.length === 0;
+
+  return (
+    <div className={cn('flex w-full flex-col gap-8')}>
+      <h1 className={cn('text-neutral-dark text-[1.875rem] leading-9 font-semibold')}>
+        전체 신청자 관리
+      </h1>
+
+      <div className={cn('flex w-full items-center justify-end')}>
+        <Button
+          variant="outlinePrimary"
+          size="sm"
+          onClick={() => downloadCsv(applications)}
+          disabled={isEmpty}
+        >
+          엑셀 형식으로 출력
+        </Button>
+      </div>
+
+      {isEmpty ? (
+        <div className={cn('flex min-h-[480px] w-full flex-1 items-center justify-center')}>
+          <p
+            className={cn(
+              'text-center text-xl font-semibold tracking-[-0.0375rem] whitespace-nowrap text-[#656e82]',
+            )}
+          >
+            등록된 신청자가 없습니다
+          </p>
+        </div>
+      ) : (
+        <div className={cn('w-full overflow-x-auto rounded-lg border border-[#e4e4e7] bg-white')}>
+          <div className={cn('min-w-[800px]')}>
+            {/* 테이블 헤더 */}
+            <div className={cn('flex items-stretch border-b border-[#e4e4e7]')}>
+              {TABLE_HEADERS.map((header, index) => (
+                <div
+                  key={index}
+                  className={cn(
+                    'flex h-12 flex-1 items-center justify-center px-4',
+                    index < TABLE_HEADERS.length - 1 && 'border-r border-[#e4e4e7]',
+                  )}
+                >
+                  <span className={cn('text-center text-sm font-semibold text-[#6b7280]')}>
+                    {header}
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            {/* 테이블 데이터 행 */}
+            {applications.map((app, rowIndex) => (
+              <div
+                key={app.id}
+                className={cn(
+                  'flex items-stretch',
+                  rowIndex < applications.length - 1 && 'border-b border-[#e4e4e7]',
+                )}
+              >
+                {/* 신청한 학과 체험 */}
+                <div
+                  className={cn(
+                    'flex h-16 flex-1 items-center justify-center border-r border-[#e4e4e7] px-4',
+                  )}
+                >
+                  <span className={cn('text-neutral-dark text-center text-sm')}>
+                    {app.activityName}
+                  </span>
+                </div>
+
+                {/* 이름 */}
+                <div
+                  className={cn(
+                    'flex h-16 flex-1 items-center justify-center border-r border-[#e4e4e7] px-4',
+                  )}
+                >
+                  <span className={cn('text-neutral-dark text-center text-sm font-medium')}>
+                    {app.name}
+                  </span>
+                </div>
+
+                {/* 전화번호 */}
+                <div
+                  className={cn(
+                    'flex h-16 flex-1 items-center justify-center border-r border-[#e4e4e7] px-4',
+                  )}
+                >
+                  <span className={cn('text-neutral-dark text-center text-sm font-medium')}>
+                    {app.phoneNumber}
+                  </span>
+                </div>
+
+                {/* 학교명 */}
+                <div
+                  className={cn(
+                    'flex h-16 flex-1 items-center justify-center border-r border-[#e4e4e7] px-4',
+                  )}
+                >
+                  <span className={cn('text-neutral-dark text-center text-sm font-medium')}>
+                    {app.schoolName}
+                  </span>
+                </div>
+
+                {/* 학번 */}
+                <div
+                  className={cn(
+                    'flex h-16 flex-1 items-center justify-center border-r border-[#e4e4e7] px-4',
+                  )}
+                >
+                  <span className={cn('text-neutral-dark text-center text-sm font-medium')}>
+                    {formatStudentId(app)}
+                  </span>
+                </div>
+
+                {/* 정보 삭제 버튼 */}
+                <div className={cn('flex h-16 flex-1 items-center justify-center px-4')}>
+                  <Button
+                    variant="outlineDanger"
+                    size="sm"
+                    onClick={() => handleDeleteClick(app.id)}
+                  >
+                    정보 삭제
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <ConfirmModal
+        isOpen={selectedId !== null}
+        onClose={handleCloseModal}
+        onConfirm={handleConfirmDelete}
+        title="정보를 삭제하시겠습니까?"
+        description="삭제된 신청자 정보는 복구할 수 없습니다."
+        confirmText="삭제"
+        cancelText="취소"
+        confirmVariant="danger"
+        cancelVariant="outlineDanger"
+        isPending={isPending}
+      />
+    </div>
+  );
+};
+
+export default ApplicantManagementTable;

--- a/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
+++ b/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
@@ -4,10 +4,10 @@ import { useState } from 'react';
 
 import {
   type ApplicationType,
-  useDeleteAdminApplication,
   useDownloadApplicationExcel,
   useGetAdminApplications,
 } from '@/entities/application';
+import { useDeleteApplicant } from '@/features/manageApplicant';
 import { cn } from '@/shared/lib';
 import { Button, ConfirmModal } from '@/shared/ui';
 
@@ -24,7 +24,7 @@ const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps)
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
   const { data: applications = [] } = useGetAdminApplications(activityId);
-  const { mutate: deleteApplication, isPending } = useDeleteAdminApplication();
+  const { mutate: deleteApplication, isPending } = useDeleteApplicant();
   const { mutate: downloadExcel } = useDownloadApplicationExcel();
 
   const handleDeleteClick = (id: number) => setSelectedId(id);

--- a/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
+++ b/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
@@ -3,45 +3,27 @@
 import { useState } from 'react';
 
 import {
-  type AdminApplicationType,
+  type ApplicationType,
   useDeleteAdminApplication,
   useGetAdminApplications,
 } from '@/entities/application';
+import { type ApiResponseType, applicationUrl, get } from '@/shared/api';
 import { cn } from '@/shared/lib';
 import { Button, ConfirmModal } from '@/shared/ui';
 
+interface ApplicantManagementTableProps {
+  activityId: number | null;
+}
+
 const TABLE_HEADERS = ['신청한 학과 체험', '이름', '전화번호', '학교명', '학번', ''];
 
-const formatStudentId = ({ grade, classNumber, number }: AdminApplicationType) =>
+const formatStudentId = ({ grade, classNumber, number }: ApplicationType) =>
   `${grade}${classNumber}${number.toString().padStart(2, '0')}`;
 
-const downloadCsv = (applications: AdminApplicationType[]) => {
-  const headers = ['신청한 학과 체험', '이름', '전화번호', '학교명', '학번'];
-  const rows = applications.map((app) => [
-    app.activityName,
-    app.name,
-    app.phoneNumber,
-    app.schoolName,
-    formatStudentId(app),
-  ]);
-
-  const csvContent = [headers, ...rows]
-    .map((row) => row.map((cell) => `"${cell}"`).join(','))
-    .join('\n');
-
-  const blob = new Blob(['﻿' + csvContent], { type: 'text/csv;charset=utf-8;' });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = '신청자_목록.csv';
-  link.click();
-  URL.revokeObjectURL(url);
-};
-
-const ApplicantManagementTable = () => {
+const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps) => {
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
-  const { data: applications = [] } = useGetAdminApplications();
+  const { data: applications = [] } = useGetAdminApplications(activityId);
   const { mutate: deleteApplication, isPending } = useDeleteAdminApplication();
 
   const handleDeleteClick = (id: number) => setSelectedId(id);
@@ -51,20 +33,28 @@ const ApplicantManagementTable = () => {
     deleteApplication(selectedId, { onSuccess: handleCloseModal });
   };
 
+  const handleExcelDownload = async () => {
+    if (activityId === null) return;
+    const response = await get<ApiResponseType<string>>(applicationUrl.getExcel(activityId));
+    const link = document.createElement('a');
+    link.href = response.data;
+    link.click();
+  };
+
   const isEmpty = applications.length === 0;
 
   return (
-    <div className={cn('flex w-full flex-col gap-8')}>
+    <div className={cn('flex flex-col gap-8')}>
       <h1 className={cn('text-neutral-dark text-[1.875rem] leading-9 font-semibold')}>
         전체 신청자 관리
       </h1>
 
-      <div className={cn('flex w-full items-center justify-end')}>
+      <div className={cn('flex items-center justify-end')}>
         <Button
           variant="outlinePrimary"
           size="sm"
-          onClick={() => downloadCsv(applications)}
-          disabled={isEmpty}
+          onClick={handleExcelDownload}
+          disabled={activityId === null}
         >
           엑셀 형식으로 출력
         </Button>
@@ -81,7 +71,7 @@ const ApplicantManagementTable = () => {
           </p>
         </div>
       ) : (
-        <div className={cn('w-full overflow-x-auto rounded-lg border border-[#e4e4e7] bg-white')}>
+        <div className={cn('overflow-x-auto rounded-lg border border-[#e4e4e7] bg-white')}>
           <div className={cn('min-w-[800px]')}>
             {/* 테이블 헤더 */}
             <div className={cn('flex items-stretch border-b border-[#e4e4e7]')}>
@@ -116,7 +106,7 @@ const ApplicantManagementTable = () => {
                   )}
                 >
                   <span className={cn('text-neutral-dark text-center text-sm')}>
-                    {app.activityName}
+                    {app.activityId}
                   </span>
                 </div>
 

--- a/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
+++ b/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
@@ -5,9 +5,9 @@ import { useState } from 'react';
 import {
   type ApplicationType,
   useDeleteAdminApplication,
+  useDownloadApplicationExcel,
   useGetAdminApplications,
 } from '@/entities/application';
-import { type ApiResponseType, applicationUrl, get } from '@/shared/api';
 import { cn } from '@/shared/lib';
 import { Button, ConfirmModal } from '@/shared/ui';
 
@@ -25,6 +25,7 @@ const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps)
 
   const { data: applications = [] } = useGetAdminApplications(activityId);
   const { mutate: deleteApplication, isPending } = useDeleteAdminApplication();
+  const { mutate: downloadExcel } = useDownloadApplicationExcel();
 
   const handleDeleteClick = (id: number) => setSelectedId(id);
   const handleCloseModal = () => setSelectedId(null);
@@ -33,12 +34,9 @@ const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps)
     deleteApplication(selectedId, { onSuccess: handleCloseModal });
   };
 
-  const handleExcelDownload = async () => {
+  const handleExcelDownload = () => {
     if (activityId === null) return;
-    const response = await get<ApiResponseType<string>>(applicationUrl.getExcel(activityId));
-    const link = document.createElement('a');
-    link.href = response.data;
-    link.click();
+    downloadExcel(activityId);
   };
 
   const isEmpty = applications.length === 0;

--- a/src/widgets/applicantManagementSidebar/index.ts
+++ b/src/widgets/applicantManagementSidebar/index.ts
@@ -1,0 +1,1 @@
+export { default as ApplicantManagementSidebar } from './ui/ApplicantManagementSidebar';

--- a/src/widgets/applicantManagementSidebar/ui/ApplicantManagementSidebar.tsx
+++ b/src/widgets/applicantManagementSidebar/ui/ApplicantManagementSidebar.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Puzzle } from 'lucide-react';
+
+import { useGetActivityList } from '@/entities/activity';
+import { cn } from '@/shared/lib';
+
+interface ApplicantManagementSidebarProps {
+  selectedActivityId: number | null;
+  onSelectActivity: (id: number) => void;
+}
+
+const ApplicantManagementSidebar = ({
+  selectedActivityId,
+  onSelectActivity,
+}: ApplicantManagementSidebarProps) => {
+  const { data: activityList } = useGetActivityList();
+  const activities = activityList?.data ?? [];
+
+  return (
+    <div className={cn('flex h-full w-full flex-col items-start gap-10')}>
+      {/* 인사말 */}
+      <div className={cn('px-4')}>
+        <p className={cn('text-base font-semibold text-[#374151]')}>
+          {'HELLO '}
+          <span className={cn('text-[#2563eb]')}>ADMIN!</span>
+        </p>
+      </div>
+
+      {/* 메뉴 영역 */}
+      <div className={cn('flex w-full flex-col gap-2')}>
+        {/* 메인 메뉴 */}
+        <div className={cn('flex w-full items-center gap-2 rounded-lg px-3 py-2.5')}>
+          <Puzzle className={cn('size-5 shrink-0 text-[#111827]')} />
+          <span className={cn('text-sm font-semibold text-[#111827]')}>신청자 관리</span>
+        </div>
+
+        {/* 서브 메뉴 — API에서 받아온 학과 체험 목록 */}
+        <div className={cn('flex w-full flex-col gap-1')}>
+          {activities.map((activity) => (
+            <button
+              key={activity.id}
+              type="button"
+              onClick={() => onSelectActivity(activity.id)}
+              className={cn(
+                'flex w-full items-center overflow-hidden rounded-lg bg-white py-2.5 pr-3 pl-10 text-left text-sm leading-[1.4]',
+                selectedActivityId === activity.id ? 'text-[#292b2f]' : 'text-gray-400',
+              )}
+            >
+              {activity.name}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ApplicantManagementSidebar;


### PR DESCRIPTION
## 개요 💡

어드민 페이지에 신청자 관리 기능을 구현합니다. 프로그램별 신청자 목록 조회, 신청자 삭제, 엑셀 다운로드 기능을 지원합니다.

## 작업내용 ⌨️

- 전체 신청자 관리 테이블 퍼블리싱
- 신청자 관리 사이드바 퍼블리싱 (활동 목록 표시 및 선택)
- 신청자 관리 API URL 추가 (`/api/v1/admin/applications`)
- 초기 `activityId`를 활동 목록 중 가장 낮은 ID로 설정
- `activityId` 미전달 및 변경 시 재요청 안 되는 문제 수정
- 엑셀 다운로드 API 호출을 `useDownloadApplicationExcel` 훅으로 분리
- `useDeleteAdminApplication`을 `features/manageApplicant`로 분리

## 스크린샷/동영상 📸

https://github.com/user-attachments/assets/32cdd547-423d-4606-b839-0729a87bfcd5

영상에 첨부되지는 않았지만 다운로드 버튼 클릭 시 파일탐색기가 열리며 다운로드가 가능합니다.


## 관련 이슈 🚨
#32 

## 리뷰 요청사항 👀

- 초기 `activityId` 선택 로직 (최솟값 기준)이 적절한지 확인 부탁드립니다.
- `features/manageApplicant` 슬라이스 구조가 FSD 규칙에 맞는지 검토 부탁드립니다.
