### PR TITLE
[fix] 학과체험 신청 반 선택 최대값 4반 → 20반으로 수정

### DIFF
--- a/src/entities/schoolInfo/ui/InfoCard.tsx
+++ b/src/entities/schoolInfo/ui/InfoCard.tsx
@@ -12,7 +12,7 @@ const InfoCard = ({ category, descriptions }: InfoCardType) => {
       <p className={cn('text-brand-primary text-[1.75rem] leading-[1.2] font-bold')}>{category}</p>
       <ul
         className={cn(
-          'text-secondary-slate flex flex-col text-[1.25rem] leading-normal font-medium xl:text-[1.5rem]',
+          'text-secondary-slate xg:text-[1.25rem] flex flex-col text-[1.125rem] leading-normal font-medium',
         )}
       >
         {descriptions.map((desc, index) => (

--- a/src/features/applyDepartment/model/schema.ts
+++ b/src/features/applyDepartment/model/schema.ts
@@ -4,7 +4,13 @@ export const ApplicationFormSchema = z
   .object({
     name: z.string().min(1, { error: '정확한 이름을 입력해주세요' }),
     grade: z.enum(['1', '2', '3']),
-    classNum: z.enum(['1', '2', '3', '4']),
+    classNum: z.string().refine(
+      (v) => {
+        const n = Number(v);
+        return Number.isInteger(n) && n >= 1 && n <= 20;
+      },
+      { message: '반을 선택해주세요' },
+    ),
     number: z
       .string()
       .min(1, { error: '번호를 입력해주세요' })

--- a/src/features/applyDepartment/model/schema.ts
+++ b/src/features/applyDepartment/model/schema.ts
@@ -2,9 +2,9 @@ import { z } from 'zod';
 
 export const ApplicationFormSchema = z
   .object({
-    name: z.string().min(1, { error: '정확한 이름을 입력해주세요' }),
-    grade: z.enum(['1', '2', '3']),
-    classNum: z.string().refine(
+    name: z.string().min(1, { message: '정확한 이름을 입력해주세요' }),
+    grade: z.enum(['1', '2', '3'], { errorMap: () => ({ message: '학년을 선택해주세요' }) }),
+    classNum: z.string({ required_error: '반을 선택해주세요' }).refine(
       (v) => {
         const n = Number(v);
         return Number.isInteger(n) && n >= 1 && n <= 20;
@@ -13,17 +13,19 @@ export const ApplicationFormSchema = z
     ),
     number: z
       .string()
-      .min(1, { error: '번호를 입력해주세요' })
-      .regex(/^\d+$/, { error: '숫자만 입력해주세요' }),
-    schoolName: z.string().min(1, { error: '학교명을 입력해주세요' }),
+      .min(1, { message: '번호를 입력해주세요' })
+      .regex(/^\d+$/, { message: '숫자만 입력해주세요' }),
+    schoolName: z.string().min(1, { message: '학교명을 입력해주세요' }),
     schoolAddress: z.string(),
     phone: z
-      .string({ error: '정확한 전화번호를 입력해주세요' })
-      .regex(/^0\d{1,2}-\d{3,4}-\d{4}$/, { error: '정확한 전화번호를 입력해주세요' }),
+      .string({ required_error: '정확한 전화번호를 입력해주세요' })
+      .regex(/^0\d{1,2}-\d{3,4}-\d{4}$/, { message: '정확한 전화번호를 입력해주세요' }),
     guardianPhone: z
-      .string({ error: '정확한 전화번호를 입력해주세요' })
-      .regex(/^0\d{1,2}-\d{3,4}-\d{4}$/, { error: '정확한 전화번호를 입력해주세요' }),
-    guardianRelation: z.enum(['부', '모', '기타']),
+      .string({ required_error: '정확한 전화번호를 입력해주세요' })
+      .regex(/^0\d{1,2}-\d{3,4}-\d{4}$/, { message: '정확한 전화번호를 입력해주세요' }),
+    guardianRelation: z.enum(['부', '모', '기타'], {
+      errorMap: () => ({ message: '보호자 관계를 선택해주세요' }),
+    }),
     customGuardianRelation: z.string(),
     agreed: z
       .boolean()

--- a/src/features/applyDepartment/model/schema.ts
+++ b/src/features/applyDepartment/model/schema.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 export const ApplicationFormSchema = z
   .object({
     name: z.string().min(1, { message: '정확한 이름을 입력해주세요' }),
-    grade: z.enum(['1', '2', '3'], { errorMap: () => ({ message: '학년을 선택해주세요' }) }),
-    classNum: z.string({ required_error: '반을 선택해주세요' }).refine(
+    grade: z.enum(['1', '2', '3'], { error: '학년을 선택해주세요' }),
+    classNum: z.string({ error: '반을 선택해주세요' }).refine(
       (v) => {
         const n = Number(v);
         return Number.isInteger(n) && n >= 1 && n <= 20;
@@ -18,14 +18,12 @@ export const ApplicationFormSchema = z
     schoolName: z.string().min(1, { message: '학교명을 입력해주세요' }),
     schoolAddress: z.string(),
     phone: z
-      .string({ required_error: '정확한 전화번호를 입력해주세요' })
+      .string({ error: '정확한 전화번호를 입력해주세요' })
       .regex(/^0\d{1,2}-\d{3,4}-\d{4}$/, { message: '정확한 전화번호를 입력해주세요' }),
     guardianPhone: z
-      .string({ required_error: '정확한 전화번호를 입력해주세요' })
+      .string({ error: '정확한 전화번호를 입력해주세요' })
       .regex(/^0\d{1,2}-\d{3,4}-\d{4}$/, { message: '정확한 전화번호를 입력해주세요' }),
-    guardianRelation: z.enum(['부', '모', '기타'], {
-      errorMap: () => ({ message: '보호자 관계를 선택해주세요' }),
-    }),
+    guardianRelation: z.enum(['부', '모', '기타'], { error: '보호자 관계를 선택해주세요' }),
     customGuardianRelation: z.string(),
     agreed: z
       .boolean()

--- a/src/widgets/applyDepartment/ui/ApplicationForm.tsx
+++ b/src/widgets/applyDepartment/ui/ApplicationForm.tsx
@@ -28,6 +28,7 @@ const formatPhoneNumber = (value: string): string => {
 
   if (digits.length <= 3) return digits;
   if (digits.length <= 7) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+  if (digits.length <= 10) return `${digits.slice(0, 3)}-${digits.slice(3, 6)}-${digits.slice(6)}`;
   return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7, 11)}`;
 };
 

--- a/src/widgets/applyDepartment/ui/ApplicationForm.tsx
+++ b/src/widgets/applyDepartment/ui/ApplicationForm.tsx
@@ -131,7 +131,7 @@ const ApplicationForm = ({ activityId, userId, onSuccess }: ApplicationFormProps
                   <SelectValue placeholder="반을 선택해주세요" />
                 </SelectTrigger>
                 <SelectContent>
-                  {Array.from({ length: 4 }, (_, i) => (
+                  {Array.from({ length: 20 }, (_, i) => (
                     <SelectItem key={i + 1} value={String(i + 1)}>
                       {i + 1}반
                     </SelectItem>


### PR DESCRIPTION
## 개요 💡

학과체험 신청 폼에서 반 선택 드롭다운이 1~4반까지만 표시되어, 5반 이상의 학생이 신청할 수 없는 버그를 수정합니다.

## 작업내용 ⌨️

- `src/widgets/applyDepartment/ui/ApplicationForm.tsx`: 반 선택 드롭다운 옵션 `length: 4` → `length: 20`
- `src/features/applyDepartment/model/schema.ts`: `z.enum(['1','2','3','4'])` → `z.string().refine()` (1~20 범위 유효성 검사)

## 관련 이슈 🚨

Closes #56