### PR TITLE
[style] 헤더 및 푸터 반응형 작업

### DIFF
--- a/src/app/admin/applicants/page.tsx
+++ b/src/app/admin/applicants/page.tsx
@@ -1,0 +1,5 @@
+import { ApplicantManagementPage } from '@/views/admin';
+
+const ApplicantsPage = () => <ApplicantManagementPage />;
+
+export default ApplicantsPage;

--- a/src/entities/application/api/hooks.ts
+++ b/src/entities/application/api/hooks.ts
@@ -2,6 +2,16 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { type ApiResponseType, applicationUrl, del, get, post } from '@/shared/api';
 
+export const useDownloadApplicationExcel = () =>
+  useMutation({
+    mutationFn: async (activityId: number) => {
+      const response = await get<ApiResponseType<string>>(applicationUrl.getExcel(activityId));
+      const link = document.createElement('a');
+      link.href = response.data;
+      link.click();
+    },
+  });
+
 import type { ApplicationType, PostApplicationMutationInput } from '../model/types';
 
 export const applicationQueryKeys = {

--- a/src/entities/application/api/hooks.ts
+++ b/src/entities/application/api/hooks.ts
@@ -46,6 +46,8 @@ export const useDownloadApplicationExcel = () =>
       const response = await get<ApiResponseType<string>>(applicationUrl.getExcel(activityId));
       const link = document.createElement('a');
       link.href = response.data;
+      document.body.appendChild(link);
       link.click();
+      document.body.removeChild(link);
     },
   });

--- a/src/entities/application/api/hooks.ts
+++ b/src/entities/application/api/hooks.ts
@@ -1,21 +1,12 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
-import { type ApiResponseType, applicationUrl, del, get, post } from '@/shared/api';
-
-export const useDownloadApplicationExcel = () =>
-  useMutation({
-    mutationFn: async (activityId: number) => {
-      const response = await get<ApiResponseType<string>>(applicationUrl.getExcel(activityId));
-      const link = document.createElement('a');
-      link.href = response.data;
-      link.click();
-    },
-  });
+import { type ApiResponseType, applicationUrl, get, post } from '@/shared/api';
 
 import type { ApplicationType, PostApplicationMutationInput } from '../model/types';
 
 export const applicationQueryKeys = {
   getMyApplication: (userId: number) => ['application', 'my', userId] as const,
+  allAdminApplications: () => ['application', 'admin', 'list'] as const,
   getAllApplications: (activityId: number) =>
     ['application', 'admin', 'list', { activityId }] as const,
 } as const;
@@ -49,15 +40,12 @@ export const useGetAdminApplications = (activityId: number | null) =>
     enabled: activityId !== null,
   });
 
-export const useDeleteAdminApplication = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (id: number) => del<void>(applicationUrl.deleteApplication(id)),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['application', 'admin', 'list'],
-      });
+export const useDownloadApplicationExcel = () =>
+  useMutation({
+    mutationFn: async (activityId: number) => {
+      const response = await get<ApiResponseType<string>>(applicationUrl.getExcel(activityId));
+      const link = document.createElement('a');
+      link.href = response.data;
+      link.click();
     },
   });
-};

--- a/src/entities/application/api/hooks.ts
+++ b/src/entities/application/api/hooks.ts
@@ -43,11 +43,15 @@ export const useGetAdminApplications = (activityId: number | null) =>
 export const useDownloadApplicationExcel = () =>
   useMutation({
     mutationFn: async (activityId: number) => {
-      const response = await get<ApiResponseType<string>>(applicationUrl.getExcel(activityId));
+      const blob = await get<Blob>(applicationUrl.getExcel(activityId), { responseType: 'blob' });
+
+      const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
-      link.href = response.data;
+      link.href = url;
+      link.download = 'applications.xlsx';
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
+      URL.revokeObjectURL(url);
     },
   });

--- a/src/entities/application/api/hooks.ts
+++ b/src/entities/application/api/hooks.ts
@@ -1,11 +1,13 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { type ApiResponseType, applicationUrl, get, post } from '@/shared/api';
+import { type ApiResponseType, applicationUrl, del, get, post } from '@/shared/api';
 
 import type { ApplicationType, PostApplicationMutationInput } from '../model/types';
 
 export const applicationQueryKeys = {
   getMyApplication: (userId: number) => ['application', 'my', userId] as const,
+  getAllApplications: (activityId: number) =>
+    ['application', 'admin', 'list', { activityId }] as const,
 } as const;
 
 export const useGetMyApplication = (userId: number, enabled = true) =>
@@ -27,3 +29,25 @@ export const usePostApplication = () =>
         params: { userId, activityId },
       }),
   });
+
+export const useGetAdminApplications = (activityId: number | null) =>
+  useQuery({
+    queryKey: applicationQueryKeys.getAllApplications(activityId ?? 0),
+    queryFn: () =>
+      get<ApiResponseType<ApplicationType[]>>(applicationUrl.getAllApplications(activityId!)),
+    select: (res) => res.data,
+    enabled: activityId !== null,
+  });
+
+export const useDeleteAdminApplication = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => del<void>(applicationUrl.deleteApplication(id)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['application', 'admin', 'list'],
+      });
+    },
+  });
+};

--- a/src/entities/schoolInfo/ui/InfoCard.tsx
+++ b/src/entities/schoolInfo/ui/InfoCard.tsx
@@ -12,7 +12,7 @@ const InfoCard = ({ category, descriptions }: InfoCardType) => {
       <p className={cn('text-brand-primary text-[1.75rem] leading-[1.2] font-bold')}>{category}</p>
       <ul
         className={cn(
-          'text-secondary-slate flex flex-col text-[1.25rem] leading-normal font-medium xl:text-[1.5rem]',
+          'text-secondary-slate xg:text-[1.25rem] flex flex-col text-[1.125rem] leading-normal font-medium',
         )}
       >
         {descriptions.map((desc, index) => (

--- a/src/features/applyDepartment/model/schema.ts
+++ b/src/features/applyDepartment/model/schema.ts
@@ -4,7 +4,13 @@ export const ApplicationFormSchema = z
   .object({
     name: z.string().min(1, { error: '정확한 이름을 입력해주세요' }),
     grade: z.enum(['1', '2', '3']),
-    classNum: z.enum(['1', '2', '3', '4']),
+    classNum: z.string().refine(
+      (v) => {
+        const n = Number(v);
+        return Number.isInteger(n) && n >= 1 && n <= 20;
+      },
+      { message: '반을 선택해주세요' },
+    ),
     number: z
       .string()
       .min(1, { error: '번호를 입력해주세요' })

--- a/src/features/applyDepartment/model/schema.ts
+++ b/src/features/applyDepartment/model/schema.ts
@@ -2,9 +2,9 @@ import { z } from 'zod';
 
 export const ApplicationFormSchema = z
   .object({
-    name: z.string().min(1, { error: '정확한 이름을 입력해주세요' }),
-    grade: z.enum(['1', '2', '3']),
-    classNum: z.string().refine(
+    name: z.string().min(1, { message: '정확한 이름을 입력해주세요' }),
+    grade: z.enum(['1', '2', '3'], { errorMap: () => ({ message: '학년을 선택해주세요' }) }),
+    classNum: z.string({ required_error: '반을 선택해주세요' }).refine(
       (v) => {
         const n = Number(v);
         return Number.isInteger(n) && n >= 1 && n <= 20;
@@ -13,17 +13,19 @@ export const ApplicationFormSchema = z
     ),
     number: z
       .string()
-      .min(1, { error: '번호를 입력해주세요' })
-      .regex(/^\d+$/, { error: '숫자만 입력해주세요' }),
-    schoolName: z.string().min(1, { error: '학교명을 입력해주세요' }),
+      .min(1, { message: '번호를 입력해주세요' })
+      .regex(/^\d+$/, { message: '숫자만 입력해주세요' }),
+    schoolName: z.string().min(1, { message: '학교명을 입력해주세요' }),
     schoolAddress: z.string(),
     phone: z
-      .string({ error: '정확한 전화번호를 입력해주세요' })
-      .regex(/^0\d{1,2}-\d{3,4}-\d{4}$/, { error: '정확한 전화번호를 입력해주세요' }),
+      .string({ required_error: '정확한 전화번호를 입력해주세요' })
+      .regex(/^0\d{1,2}-\d{3,4}-\d{4}$/, { message: '정확한 전화번호를 입력해주세요' }),
     guardianPhone: z
-      .string({ error: '정확한 전화번호를 입력해주세요' })
-      .regex(/^0\d{1,2}-\d{3,4}-\d{4}$/, { error: '정확한 전화번호를 입력해주세요' }),
-    guardianRelation: z.enum(['부', '모', '기타']),
+      .string({ required_error: '정확한 전화번호를 입력해주세요' })
+      .regex(/^0\d{1,2}-\d{3,4}-\d{4}$/, { message: '정확한 전화번호를 입력해주세요' }),
+    guardianRelation: z.enum(['부', '모', '기타'], {
+      errorMap: () => ({ message: '보호자 관계를 선택해주세요' }),
+    }),
     customGuardianRelation: z.string(),
     agreed: z
       .boolean()

--- a/src/features/applyDepartment/model/schema.ts
+++ b/src/features/applyDepartment/model/schema.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 export const ApplicationFormSchema = z
   .object({
     name: z.string().min(1, { message: '정확한 이름을 입력해주세요' }),
-    grade: z.enum(['1', '2', '3'], { errorMap: () => ({ message: '학년을 선택해주세요' }) }),
-    classNum: z.string({ required_error: '반을 선택해주세요' }).refine(
+    grade: z.enum(['1', '2', '3'], { error: '학년을 선택해주세요' }),
+    classNum: z.string({ error: '반을 선택해주세요' }).refine(
       (v) => {
         const n = Number(v);
         return Number.isInteger(n) && n >= 1 && n <= 20;
@@ -18,14 +18,12 @@ export const ApplicationFormSchema = z
     schoolName: z.string().min(1, { message: '학교명을 입력해주세요' }),
     schoolAddress: z.string(),
     phone: z
-      .string({ required_error: '정확한 전화번호를 입력해주세요' })
+      .string({ error: '정확한 전화번호를 입력해주세요' })
       .regex(/^0\d{1,2}-\d{3,4}-\d{4}$/, { message: '정확한 전화번호를 입력해주세요' }),
     guardianPhone: z
-      .string({ required_error: '정확한 전화번호를 입력해주세요' })
+      .string({ error: '정확한 전화번호를 입력해주세요' })
       .regex(/^0\d{1,2}-\d{3,4}-\d{4}$/, { message: '정확한 전화번호를 입력해주세요' }),
-    guardianRelation: z.enum(['부', '모', '기타'], {
-      errorMap: () => ({ message: '보호자 관계를 선택해주세요' }),
-    }),
+    guardianRelation: z.enum(['부', '모', '기타'], { error: '보호자 관계를 선택해주세요' }),
     customGuardianRelation: z.string(),
     agreed: z
       .boolean()

--- a/src/features/manageApplicant/index.ts
+++ b/src/features/manageApplicant/index.ts
@@ -1,0 +1,1 @@
+export { useDeleteApplicant } from './model/useDeleteApplicant';

--- a/src/features/manageApplicant/model/useDeleteApplicant.ts
+++ b/src/features/manageApplicant/model/useDeleteApplicant.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { applicationQueryKeys } from '@/entities/application';
+import { applicationUrl, del } from '@/shared/api';
+
+export const useDeleteApplicant = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => del<void>(applicationUrl.deleteApplication(id)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: applicationQueryKeys.allAdminApplications(),
+      });
+    },
+  });
+};

--- a/src/shared/api/apiUrls.ts
+++ b/src/shared/api/apiUrls.ts
@@ -22,4 +22,7 @@ export const activityUrl = {
 export const applicationUrl = {
   getMyApplication: () => '/v1/application/my',
   postApplication: () => '/v1/application/apply',
+  getAllApplications: (id: number) => `/v1/application/admin/applications?activityId=${id}`,
+  deleteApplication: (id: number) => `/v1/application/admin/cancel/${id}`,
+  getExcel: (id: number) => `/v1/application/admin/excel?activityId=${id}`,
 } as const;

--- a/src/shared/assets/HamburgerIcon.tsx
+++ b/src/shared/assets/HamburgerIcon.tsx
@@ -1,0 +1,13 @@
+const HamburgerIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="none">
+    <path
+      d="M5 9H27M5 16H27M5 23H27"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default HamburgerIcon;

--- a/src/shared/assets/index.ts
+++ b/src/shared/assets/index.ts
@@ -3,6 +3,7 @@ export { default as BottomArrow } from './BottomArrow';
 export { default as CheckIcon } from './CheckIcon';
 export { default as GoogleIcon } from './GoogleIcon';
 export { default as GSMTitle } from './GSMTitle';
+export { default as HamburgerIcon } from './HamburgerIcon';
 export { default as KakaoIcon } from './KakaoIcon';
 export { default as Logo } from './Logo';
 export { default as SearchIcon } from './SearchIcon';

--- a/src/views/admin/index.ts
+++ b/src/views/admin/index.ts
@@ -1,1 +1,2 @@
 export { default as AdminPage } from './ui/AdminPage';
+export { default as ApplicantManagementPage } from './ui/ApplicantManagementPage';

--- a/src/views/admin/ui/ApplicantManagementPage.tsx
+++ b/src/views/admin/ui/ApplicantManagementPage.tsx
@@ -7,7 +7,7 @@ import { ApplicantManagementTable } from '@/widgets/applicantManagement';
 import { ApplicantManagementSidebar } from '@/widgets/applicantManagementSidebar';
 
 const ApplicantManagementPage = () => {
-  const [selectedActivityId, setSelectedActivityId] = useState<number | null>(null);
+  const [selectedActivityId, setSelectedActivityId] = useState<number | null>(1);
 
   return (
     <div className={cn('flex min-h-screen w-full px-[3rem]')}>
@@ -20,7 +20,7 @@ const ApplicantManagementPage = () => {
       </aside>
 
       {/* 본문 */}
-      <main className={cn('flex max-w-[80rem] flex-1 flex-col p-8')}>
+      <main className={cn('flex max-w-7xl flex-1 flex-col p-8')}>
         <ApplicantManagementTable activityId={selectedActivityId} />
       </main>
     </div>

--- a/src/views/admin/ui/ApplicantManagementPage.tsx
+++ b/src/views/admin/ui/ApplicantManagementPage.tsx
@@ -16,7 +16,7 @@ const ApplicantManagementPage = () => {
   const effectiveActivityId = selectedActivityId ?? minId;
 
   return (
-    <div className={cn('flex min-h-screen w-full px-[3rem]')}>
+    <div className={cn('flex min-h-screen w-full px-12')}>
       {/* 사이드바 */}
       <aside className={cn('w-55 shrink-0 px-4 py-10')}>
         <ApplicantManagementSidebar

--- a/src/views/admin/ui/ApplicantManagementPage.tsx
+++ b/src/views/admin/ui/ApplicantManagementPage.tsx
@@ -1,5 +1,30 @@
-import { ApplicantManagementTable } from '@/widgets/applicantManagement';
+'use client';
 
-const ApplicantManagementPage = () => <ApplicantManagementTable />;
+import { useState } from 'react';
+
+import { cn } from '@/shared/lib';
+import { ApplicantManagementTable } from '@/widgets/applicantManagement';
+import { ApplicantManagementSidebar } from '@/widgets/applicantManagementSidebar';
+
+const ApplicantManagementPage = () => {
+  const [selectedActivityId, setSelectedActivityId] = useState<number | null>(null);
+
+  return (
+    <div className={cn('flex min-h-screen w-full px-[3rem]')}>
+      {/* 사이드바 */}
+      <aside className={cn('w-55 shrink-0 px-4 py-10')}>
+        <ApplicantManagementSidebar
+          selectedActivityId={selectedActivityId}
+          onSelectActivity={setSelectedActivityId}
+        />
+      </aside>
+
+      {/* 본문 */}
+      <main className={cn('flex max-w-[80rem] flex-1 flex-col p-8')}>
+        <ApplicantManagementTable activityId={selectedActivityId} />
+      </main>
+    </div>
+  );
+};
 
 export default ApplicantManagementPage;

--- a/src/views/admin/ui/ApplicantManagementPage.tsx
+++ b/src/views/admin/ui/ApplicantManagementPage.tsx
@@ -2,26 +2,32 @@
 
 import { useState } from 'react';
 
+import { useGetActivityList } from '@/entities/activity';
 import { cn } from '@/shared/lib';
 import { ApplicantManagementTable } from '@/widgets/applicantManagement';
 import { ApplicantManagementSidebar } from '@/widgets/applicantManagementSidebar';
 
 const ApplicantManagementPage = () => {
-  const [selectedActivityId, setSelectedActivityId] = useState<number | null>(1);
+  const [selectedActivityId, setSelectedActivityId] = useState<number | null>(null);
+  const { data: activityList } = useGetActivityList();
+
+  const activities = activityList?.data ?? [];
+  const minId = activities.length > 0 ? Math.min(...activities.map((a) => a.id)) : null;
+  const effectiveActivityId = selectedActivityId ?? minId;
 
   return (
     <div className={cn('flex min-h-screen w-full px-[3rem]')}>
       {/* 사이드바 */}
       <aside className={cn('w-55 shrink-0 px-4 py-10')}>
         <ApplicantManagementSidebar
-          selectedActivityId={selectedActivityId}
+          selectedActivityId={effectiveActivityId}
           onSelectActivity={setSelectedActivityId}
         />
       </aside>
 
       {/* 본문 */}
       <main className={cn('flex max-w-7xl flex-1 flex-col p-8')}>
-        <ApplicantManagementTable activityId={selectedActivityId} />
+        <ApplicantManagementTable activityId={effectiveActivityId} />
       </main>
     </div>
   );

--- a/src/views/admin/ui/ApplicantManagementPage.tsx
+++ b/src/views/admin/ui/ApplicantManagementPage.tsx
@@ -1,0 +1,5 @@
+import { ApplicantManagementTable } from '@/widgets/applicantManagement';
+
+const ApplicantManagementPage = () => <ApplicantManagementTable />;
+
+export default ApplicantManagementPage;

--- a/src/widgets/applicantManagement/index.ts
+++ b/src/widgets/applicantManagement/index.ts
@@ -1,0 +1,1 @@
+export { default as ApplicantManagementTable } from './ui/ApplicantManagementTable';

--- a/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
+++ b/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import { useGetActivityList } from '@/entities/activity';
 import {
   type ApplicationType,
   useDownloadApplicationExcel,
@@ -24,6 +25,8 @@ const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps)
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
   const { data: applications = [] } = useGetAdminApplications(activityId);
+  const { data: activityList } = useGetActivityList();
+  const activities = activityList?.data ?? [];
   const { mutate: deleteApplication, isPending } = useDeleteApplicant();
   const { mutate: downloadExcel } = useDownloadApplicationExcel();
 
@@ -104,7 +107,7 @@ const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps)
                   )}
                 >
                   <span className={cn('text-neutral-dark text-center text-sm')}>
-                    {app.activityId}
+                    {activities.find((act) => act.id === app.activityId)?.name ?? app.activityId}
                   </span>
                 </div>
 

--- a/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
+++ b/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
@@ -59,7 +59,7 @@ const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps)
       </div>
 
       {isEmpty ? (
-        <div className={cn('flex min-h-[480px] w-full flex-1 items-center justify-center')}>
+        <div className={cn('flex min-h-120 w-full flex-1 items-center justify-center')}>
           <p
             className={cn(
               'text-center text-xl font-semibold tracking-[-0.0375rem] whitespace-nowrap text-[#656e82]',
@@ -70,7 +70,7 @@ const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps)
         </div>
       ) : (
         <div className={cn('overflow-x-auto rounded-lg border border-[#e4e4e7] bg-white')}>
-          <div className={cn('min-w-[800px]')}>
+          <div className={cn('min-w-200')}>
             {/* 테이블 헤더 */}
             <div className={cn('flex items-stretch border-b border-[#e4e4e7]')}>
               {TABLE_HEADERS.map((header, index) => (

--- a/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
+++ b/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useState } from 'react';
+
+import {
+  type AdminApplicationType,
+  useDeleteAdminApplication,
+  useGetAdminApplications,
+} from '@/entities/application';
+import { cn } from '@/shared/lib';
+import { Button, ConfirmModal } from '@/shared/ui';
+
+const TABLE_HEADERS = ['신청한 학과 체험', '이름', '전화번호', '학교명', '학번', ''];
+
+const formatStudentId = ({ grade, classNumber, number }: AdminApplicationType) =>
+  `${grade}${classNumber}${number.toString().padStart(2, '0')}`;
+
+const downloadCsv = (applications: AdminApplicationType[]) => {
+  const headers = ['신청한 학과 체험', '이름', '전화번호', '학교명', '학번'];
+  const rows = applications.map((app) => [
+    app.activityName,
+    app.name,
+    app.phoneNumber,
+    app.schoolName,
+    formatStudentId(app),
+  ]);
+
+  const csvContent = [headers, ...rows]
+    .map((row) => row.map((cell) => `"${cell}"`).join(','))
+    .join('\n');
+
+  const blob = new Blob(['﻿' + csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = '신청자_목록.csv';
+  link.click();
+  URL.revokeObjectURL(url);
+};
+
+const ApplicantManagementTable = () => {
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  const { data: applications = [] } = useGetAdminApplications();
+  const { mutate: deleteApplication, isPending } = useDeleteAdminApplication();
+
+  const handleDeleteClick = (id: number) => setSelectedId(id);
+  const handleCloseModal = () => setSelectedId(null);
+  const handleConfirmDelete = () => {
+    if (selectedId === null) return;
+    deleteApplication(selectedId, { onSuccess: handleCloseModal });
+  };
+
+  const isEmpty = applications.length === 0;
+
+  return (
+    <div className={cn('flex w-full flex-col gap-8')}>
+      <h1 className={cn('text-neutral-dark text-[1.875rem] leading-9 font-semibold')}>
+        전체 신청자 관리
+      </h1>
+
+      <div className={cn('flex w-full items-center justify-end')}>
+        <Button
+          variant="outlinePrimary"
+          size="sm"
+          onClick={() => downloadCsv(applications)}
+          disabled={isEmpty}
+        >
+          엑셀 형식으로 출력
+        </Button>
+      </div>
+
+      {isEmpty ? (
+        <div className={cn('flex min-h-[480px] w-full flex-1 items-center justify-center')}>
+          <p
+            className={cn(
+              'text-center text-xl font-semibold tracking-[-0.0375rem] whitespace-nowrap text-[#656e82]',
+            )}
+          >
+            등록된 신청자가 없습니다
+          </p>
+        </div>
+      ) : (
+        <div className={cn('w-full overflow-x-auto rounded-lg border border-[#e4e4e7] bg-white')}>
+          <div className={cn('min-w-[800px]')}>
+            {/* 테이블 헤더 */}
+            <div className={cn('flex items-stretch border-b border-[#e4e4e7]')}>
+              {TABLE_HEADERS.map((header, index) => (
+                <div
+                  key={index}
+                  className={cn(
+                    'flex h-12 flex-1 items-center justify-center px-4',
+                    index < TABLE_HEADERS.length - 1 && 'border-r border-[#e4e4e7]',
+                  )}
+                >
+                  <span className={cn('text-center text-sm font-semibold text-[#6b7280]')}>
+                    {header}
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            {/* 테이블 데이터 행 */}
+            {applications.map((app, rowIndex) => (
+              <div
+                key={app.id}
+                className={cn(
+                  'flex items-stretch',
+                  rowIndex < applications.length - 1 && 'border-b border-[#e4e4e7]',
+                )}
+              >
+                {/* 신청한 학과 체험 */}
+                <div
+                  className={cn(
+                    'flex h-16 flex-1 items-center justify-center border-r border-[#e4e4e7] px-4',
+                  )}
+                >
+                  <span className={cn('text-neutral-dark text-center text-sm')}>
+                    {app.activityName}
+                  </span>
+                </div>
+
+                {/* 이름 */}
+                <div
+                  className={cn(
+                    'flex h-16 flex-1 items-center justify-center border-r border-[#e4e4e7] px-4',
+                  )}
+                >
+                  <span className={cn('text-neutral-dark text-center text-sm font-medium')}>
+                    {app.name}
+                  </span>
+                </div>
+
+                {/* 전화번호 */}
+                <div
+                  className={cn(
+                    'flex h-16 flex-1 items-center justify-center border-r border-[#e4e4e7] px-4',
+                  )}
+                >
+                  <span className={cn('text-neutral-dark text-center text-sm font-medium')}>
+                    {app.phoneNumber}
+                  </span>
+                </div>
+
+                {/* 학교명 */}
+                <div
+                  className={cn(
+                    'flex h-16 flex-1 items-center justify-center border-r border-[#e4e4e7] px-4',
+                  )}
+                >
+                  <span className={cn('text-neutral-dark text-center text-sm font-medium')}>
+                    {app.schoolName}
+                  </span>
+                </div>
+
+                {/* 학번 */}
+                <div
+                  className={cn(
+                    'flex h-16 flex-1 items-center justify-center border-r border-[#e4e4e7] px-4',
+                  )}
+                >
+                  <span className={cn('text-neutral-dark text-center text-sm font-medium')}>
+                    {formatStudentId(app)}
+                  </span>
+                </div>
+
+                {/* 정보 삭제 버튼 */}
+                <div className={cn('flex h-16 flex-1 items-center justify-center px-4')}>
+                  <Button
+                    variant="outlineDanger"
+                    size="sm"
+                    onClick={() => handleDeleteClick(app.id)}
+                  >
+                    정보 삭제
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <ConfirmModal
+        isOpen={selectedId !== null}
+        onClose={handleCloseModal}
+        onConfirm={handleConfirmDelete}
+        title="정보를 삭제하시겠습니까?"
+        description="삭제된 신청자 정보는 복구할 수 없습니다."
+        confirmText="삭제"
+        cancelText="취소"
+        confirmVariant="danger"
+        cancelVariant="outlineDanger"
+        isPending={isPending}
+      />
+    </div>
+  );
+};
+
+export default ApplicantManagementTable;

--- a/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
+++ b/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
@@ -4,10 +4,10 @@ import { useState } from 'react';
 
 import {
   type ApplicationType,
-  useDeleteAdminApplication,
   useDownloadApplicationExcel,
   useGetAdminApplications,
 } from '@/entities/application';
+import { useDeleteApplicant } from '@/features/manageApplicant';
 import { cn } from '@/shared/lib';
 import { Button, ConfirmModal } from '@/shared/ui';
 
@@ -24,7 +24,7 @@ const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps)
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
   const { data: applications = [] } = useGetAdminApplications(activityId);
-  const { mutate: deleteApplication, isPending } = useDeleteAdminApplication();
+  const { mutate: deleteApplication, isPending } = useDeleteApplicant();
   const { mutate: downloadExcel } = useDownloadApplicationExcel();
 
   const handleDeleteClick = (id: number) => setSelectedId(id);

--- a/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
+++ b/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
@@ -3,45 +3,27 @@
 import { useState } from 'react';
 
 import {
-  type AdminApplicationType,
+  type ApplicationType,
   useDeleteAdminApplication,
   useGetAdminApplications,
 } from '@/entities/application';
+import { type ApiResponseType, applicationUrl, get } from '@/shared/api';
 import { cn } from '@/shared/lib';
 import { Button, ConfirmModal } from '@/shared/ui';
 
+interface ApplicantManagementTableProps {
+  activityId: number | null;
+}
+
 const TABLE_HEADERS = ['신청한 학과 체험', '이름', '전화번호', '학교명', '학번', ''];
 
-const formatStudentId = ({ grade, classNumber, number }: AdminApplicationType) =>
+const formatStudentId = ({ grade, classNumber, number }: ApplicationType) =>
   `${grade}${classNumber}${number.toString().padStart(2, '0')}`;
 
-const downloadCsv = (applications: AdminApplicationType[]) => {
-  const headers = ['신청한 학과 체험', '이름', '전화번호', '학교명', '학번'];
-  const rows = applications.map((app) => [
-    app.activityName,
-    app.name,
-    app.phoneNumber,
-    app.schoolName,
-    formatStudentId(app),
-  ]);
-
-  const csvContent = [headers, ...rows]
-    .map((row) => row.map((cell) => `"${cell}"`).join(','))
-    .join('\n');
-
-  const blob = new Blob(['﻿' + csvContent], { type: 'text/csv;charset=utf-8;' });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = '신청자_목록.csv';
-  link.click();
-  URL.revokeObjectURL(url);
-};
-
-const ApplicantManagementTable = () => {
+const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps) => {
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
-  const { data: applications = [] } = useGetAdminApplications();
+  const { data: applications = [] } = useGetAdminApplications(activityId);
   const { mutate: deleteApplication, isPending } = useDeleteAdminApplication();
 
   const handleDeleteClick = (id: number) => setSelectedId(id);
@@ -51,20 +33,28 @@ const ApplicantManagementTable = () => {
     deleteApplication(selectedId, { onSuccess: handleCloseModal });
   };
 
+  const handleExcelDownload = async () => {
+    if (activityId === null) return;
+    const response = await get<ApiResponseType<string>>(applicationUrl.getExcel(activityId));
+    const link = document.createElement('a');
+    link.href = response.data;
+    link.click();
+  };
+
   const isEmpty = applications.length === 0;
 
   return (
-    <div className={cn('flex w-full flex-col gap-8')}>
+    <div className={cn('flex flex-col gap-8')}>
       <h1 className={cn('text-neutral-dark text-[1.875rem] leading-9 font-semibold')}>
         전체 신청자 관리
       </h1>
 
-      <div className={cn('flex w-full items-center justify-end')}>
+      <div className={cn('flex items-center justify-end')}>
         <Button
           variant="outlinePrimary"
           size="sm"
-          onClick={() => downloadCsv(applications)}
-          disabled={isEmpty}
+          onClick={handleExcelDownload}
+          disabled={activityId === null}
         >
           엑셀 형식으로 출력
         </Button>
@@ -81,7 +71,7 @@ const ApplicantManagementTable = () => {
           </p>
         </div>
       ) : (
-        <div className={cn('w-full overflow-x-auto rounded-lg border border-[#e4e4e7] bg-white')}>
+        <div className={cn('overflow-x-auto rounded-lg border border-[#e4e4e7] bg-white')}>
           <div className={cn('min-w-[800px]')}>
             {/* 테이블 헤더 */}
             <div className={cn('flex items-stretch border-b border-[#e4e4e7]')}>
@@ -116,7 +106,7 @@ const ApplicantManagementTable = () => {
                   )}
                 >
                   <span className={cn('text-neutral-dark text-center text-sm')}>
-                    {app.activityName}
+                    {app.activityId}
                   </span>
                 </div>
 

--- a/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
+++ b/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
@@ -5,9 +5,9 @@ import { useState } from 'react';
 import {
   type ApplicationType,
   useDeleteAdminApplication,
+  useDownloadApplicationExcel,
   useGetAdminApplications,
 } from '@/entities/application';
-import { type ApiResponseType, applicationUrl, get } from '@/shared/api';
 import { cn } from '@/shared/lib';
 import { Button, ConfirmModal } from '@/shared/ui';
 
@@ -25,6 +25,7 @@ const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps)
 
   const { data: applications = [] } = useGetAdminApplications(activityId);
   const { mutate: deleteApplication, isPending } = useDeleteAdminApplication();
+  const { mutate: downloadExcel } = useDownloadApplicationExcel();
 
   const handleDeleteClick = (id: number) => setSelectedId(id);
   const handleCloseModal = () => setSelectedId(null);
@@ -33,12 +34,9 @@ const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps)
     deleteApplication(selectedId, { onSuccess: handleCloseModal });
   };
 
-  const handleExcelDownload = async () => {
+  const handleExcelDownload = () => {
     if (activityId === null) return;
-    const response = await get<ApiResponseType<string>>(applicationUrl.getExcel(activityId));
-    const link = document.createElement('a');
-    link.href = response.data;
-    link.click();
+    downloadExcel(activityId);
   };
 
   const isEmpty = applications.length === 0;

--- a/src/widgets/applicantManagementSidebar/index.ts
+++ b/src/widgets/applicantManagementSidebar/index.ts
@@ -1,0 +1,1 @@
+export { default as ApplicantManagementSidebar } from './ui/ApplicantManagementSidebar';

--- a/src/widgets/applicantManagementSidebar/ui/ApplicantManagementSidebar.tsx
+++ b/src/widgets/applicantManagementSidebar/ui/ApplicantManagementSidebar.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Puzzle } from 'lucide-react';
+
+import { useGetActivityList } from '@/entities/activity';
+import { cn } from '@/shared/lib';
+
+interface ApplicantManagementSidebarProps {
+  selectedActivityId: number | null;
+  onSelectActivity: (id: number) => void;
+}
+
+const ApplicantManagementSidebar = ({
+  selectedActivityId,
+  onSelectActivity,
+}: ApplicantManagementSidebarProps) => {
+  const { data: activityList } = useGetActivityList();
+  const activities = activityList?.data ?? [];
+
+  return (
+    <div className={cn('flex h-full w-full flex-col items-start gap-10')}>
+      {/* 인사말 */}
+      <div className={cn('px-4')}>
+        <p className={cn('text-base font-semibold text-[#374151]')}>
+          {'HELLO '}
+          <span className={cn('text-[#2563eb]')}>ADMIN!</span>
+        </p>
+      </div>
+
+      {/* 메뉴 영역 */}
+      <div className={cn('flex w-full flex-col gap-2')}>
+        {/* 메인 메뉴 */}
+        <div className={cn('flex w-full items-center gap-2 rounded-lg px-3 py-2.5')}>
+          <Puzzle className={cn('size-5 shrink-0 text-[#111827]')} />
+          <span className={cn('text-sm font-semibold text-[#111827]')}>신청자 관리</span>
+        </div>
+
+        {/* 서브 메뉴 — API에서 받아온 학과 체험 목록 */}
+        <div className={cn('flex w-full flex-col gap-1')}>
+          {activities.map((activity) => (
+            <button
+              key={activity.id}
+              type="button"
+              onClick={() => onSelectActivity(activity.id)}
+              className={cn(
+                'flex w-full items-center overflow-hidden rounded-lg bg-white py-2.5 pr-3 pl-10 text-left text-sm leading-[1.4]',
+                selectedActivityId === activity.id ? 'text-[#292b2f]' : 'text-gray-400',
+              )}
+            >
+              {activity.name}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ApplicantManagementSidebar;

--- a/src/widgets/applyDepartment/ui/ApplicationForm.tsx
+++ b/src/widgets/applyDepartment/ui/ApplicationForm.tsx
@@ -28,6 +28,7 @@ const formatPhoneNumber = (value: string): string => {
 
   if (digits.length <= 3) return digits;
   if (digits.length <= 7) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+  if (digits.length <= 10) return `${digits.slice(0, 3)}-${digits.slice(3, 6)}-${digits.slice(6)}`;
   return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7, 11)}`;
 };
 

--- a/src/widgets/applyDepartment/ui/ApplicationForm.tsx
+++ b/src/widgets/applyDepartment/ui/ApplicationForm.tsx
@@ -131,7 +131,7 @@ const ApplicationForm = ({ activityId, userId, onSuccess }: ApplicationFormProps
                   <SelectValue placeholder="반을 선택해주세요" />
                 </SelectTrigger>
                 <SelectContent>
-                  {Array.from({ length: 4 }, (_, i) => (
+                  {Array.from({ length: 20 }, (_, i) => (
                     <SelectItem key={i + 1} value={String(i + 1)}>
                       {i + 1}반
                     </SelectItem>

--- a/src/widgets/footer/ui/Footer.tsx
+++ b/src/widgets/footer/ui/Footer.tsx
@@ -7,44 +7,22 @@ const Footer = () => {
   const CURRENT_YEAR = new Date().getFullYear();
 
   return (
-    <footer
-      className={cn(
-        'flex',
-        'w-full',
-        'items-center',
-        'justify-center',
-        'bg-gray-50',
-        'px-80',
-        'py-[1.3438rem]',
-        // 'md:px-10',
-        // 'lg:px-15',
-        // 'xl:px-20',
-        // 'fhd:px-80',
-      )}
-    >
+    <footer className={cn('bg-ghost-white flex w-full items-center justify-center')}>
       <div
         className={cn(
-          'flex',
-          'w-full',
-          'flex-col',
-          'items-start',
-          'gap-10',
-          'md:flex-row',
-          'md:items-center',
-          'md:justify-between',
-          'md:gap-2',
+          'flex w-full flex-col items-start gap-10',
+          'px-12 py-15',
+          'lg:flex-row lg:items-center lg:justify-between lg:gap-2 lg:px-20 lg:py-5',
+          'min-[1440px]:max-w-360',
         )}
       >
         <FooterGSMLogo />
 
-        <div className={cn('flex', 'flex-col', 'items-start', 'gap-4', 'md:items-end')}>
-          <div className={cn('flex', 'flex-col', 'items-start', 'gap-2', 'md:items-end')}>
+        <div className={cn('flex w-full flex-col items-end gap-4', 'lg:w-auto')}>
+          <div className={cn('flex w-full flex-col items-end gap-2', 'lg:w-auto')}>
             <p
               className={cn(
-                'text-[1.125rem]/[1.6875rem]',
-                'font-normal',
-                'text-slate-600',
-                'md:text-right',
+                'text-neutral-slate text-right text-[1.125rem]/[1.6875rem] font-normal',
               )}
             >
               ©{CURRENT_YEAR} Copyright 광주소프트웨어마이스터고등학교{' '}
@@ -52,12 +30,12 @@ const Footer = () => {
               ALL RIGHTS RESERVED.
             </p>
 
-            <div className={cn('flex', 'flex-col', 'gap-6', 'md:flex-row')}>
+            <div className={cn('flex flex-wrap justify-end gap-6')}>
               {LINKS.map(({ text, link }) => (
                 <a
                   key={text}
                   href={link}
-                  className={cn('text-[1.125rem]/[1.6875rem]', 'font-bold', 'text-slate-600')}
+                  className={cn('text-[1.125rem]/[1.6875rem]', 'font-bold', 'text-neutral-slate')}
                   target="_blank"
                   rel="noreferrer"
                 >
@@ -67,14 +45,7 @@ const Footer = () => {
             </div>
           </div>
 
-          <p
-            className={cn(
-              'text-[0.875rem]/[1.25rem]',
-              'font-normal',
-              'text-dark-utility',
-              'md:text-right',
-            )}
-          >
+          <p className={cn('text-dark-utility text-right text-[0.875rem]/[1.25rem] font-normal')}>
             우) 62423 광주광역시 광산구 상무대로 312
             <br />
             교무실 062)949-6800(08:30~16:30) 행정실 062)949-6806(08:30~16:30)

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -113,7 +113,7 @@ const Header = () => {
       {isMenuOpen && (
         <>
           <div
-            className={cn('fixed inset-x-0 top-25 bottom-0 z-40 lg:hidden')}
+            className={cn('fixed inset-x-0 top-25 bottom-0 z-40 bg-black/20 lg:hidden')}
             onClick={handleMenuClose}
           />
           <div

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -6,12 +6,13 @@ import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 
 import { useQueryClient } from '@tanstack/react-query';
+import { X } from 'lucide-react';
 import { toast } from 'react-toastify';
 
 import { usePostSignOut } from '@/entities/auth';
 import { checkIsAdmin, useGetMyInfo, userQueryKeys } from '@/entities/user';
 import { LoginModal } from '@/features/auth';
-import { Logo } from '@/shared/assets';
+import { HamburgerIcon, Logo } from '@/shared/assets';
 import { cn } from '@/shared/lib';
 import { Button, buttonVariants } from '@/shared/ui';
 
@@ -21,6 +22,7 @@ const Header = () => {
   const pathname = usePathname();
   const router = useRouter();
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const queryClient = useQueryClient();
   const { data: user } = useGetMyInfo();
@@ -40,12 +42,17 @@ const Header = () => {
     });
   };
 
+  const handleMenuClose = () => setIsMenuOpen(false);
+
   return (
-    <header className={cn('w-full bg-white')}>
+    <header className={cn('relative w-full bg-white')}>
       <div
         className={cn(
           'mx-auto flex h-25 max-w-480 items-center justify-between',
-          isAdminRole && !isAdmin ? 'pr-[6.69rem] pl-80' : 'px-80',
+          'px-8',
+          isAdminRole && !isAdmin
+            ? 'lg:px-12 xl:px-20 2xl:pr-[6.69rem] 2xl:pl-80'
+            : 'lg:px-12 xl:px-20 2xl:px-80',
         )}
       >
         <Link href="/" className={cn('flex items-center gap-3')}>
@@ -53,7 +60,7 @@ const Header = () => {
           <span className={cn('text-neutral-dark text-[1.5rem] font-bold')}>Ready, GSM</span>
         </Link>
 
-        <nav className={cn('flex items-center gap-12')}>
+        <nav className={cn('hidden items-center gap-12 lg:flex')}>
           {links.map((link) => {
             const isActive = link.href === '/' ? pathname === '/' : pathname.startsWith(link.href);
 
@@ -78,7 +85,7 @@ const Header = () => {
           })}
         </nav>
 
-        <div className={cn('flex items-center gap-4')}>
+        <div className={cn('hidden items-center gap-4 lg:flex')}>
           {user ? (
             <Button onClick={handleSignOut} variant="outlinePrimary" size="md">
               로그아웃
@@ -94,7 +101,81 @@ const Header = () => {
             </Link>
           )}
         </div>
+
+        <button
+          onClick={() => setIsMenuOpen((prev) => !prev)}
+          className={cn('flex items-center justify-center lg:hidden')}
+          aria-label={isMenuOpen ? '메뉴 닫기' : '메뉴 열기'}
+        >
+          {isMenuOpen ? <X size={32} /> : <HamburgerIcon />}
+        </button>
       </div>
+
+      {isMenuOpen && (
+        <div
+          className={cn(
+            'border-border-variant absolute top-full left-0 z-50 w-full border-t bg-white lg:hidden',
+          )}
+        >
+          <div className={cn('mx-auto flex max-w-480 flex-col px-8 py-6')}>
+            <nav className={cn('flex flex-col gap-6')}>
+              {links.map((link) => {
+                const isActive =
+                  link.href === '/' ? pathname === '/' : pathname.startsWith(link.href);
+
+                return (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    onClick={handleMenuClose}
+                    className={cn(
+                      'text-2xl leading-[120%] font-semibold transition-colors',
+                      isActive ? 'text-neutral-dark' : 'text-soft-gray',
+                    )}
+                  >
+                    {link.label}
+                  </Link>
+                );
+              })}
+            </nav>
+
+            <div className={cn('mt-8 flex flex-col gap-3')}>
+              {user ? (
+                <Button
+                  onClick={() => {
+                    handleSignOut();
+                    handleMenuClose();
+                  }}
+                  variant="outlinePrimary"
+                  size="md"
+                >
+                  로그아웃
+                </Button>
+              ) : (
+                <Button
+                  onClick={() => {
+                    setIsLoginModalOpen(true);
+                    handleMenuClose();
+                  }}
+                  variant="default"
+                  size="md"
+                >
+                  로그인
+                </Button>
+              )}
+              {isAdminRole && !isAdmin && (
+                <Link
+                  href="/admin"
+                  onClick={handleMenuClose}
+                  className={cn(buttonVariants({ variant: 'default', size: 'md' }))}
+                >
+                  어드민 페이지로 이동
+                </Link>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       <LoginModal isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />
     </header>

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -118,7 +118,7 @@ const Header = () => {
           />
           <div
             className={cn(
-              'fixed top-25 right-0 bottom-0 z-40 bg-white lg:hidden',
+              'fixed top-25 right-0 bottom-0 z-40 overflow-y-auto bg-white lg:hidden',
               'inline-flex flex-col items-end pt-9 pr-6 pb-34.25 pl-12.75',
             )}
           >

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -17,6 +17,7 @@ import { cn } from '@/shared/lib';
 import { Button, buttonVariants } from '@/shared/ui';
 
 import { NAV_LINKS } from '../model/navigation';
+import NavLink from './NavLink';
 
 const Header = () => {
   const pathname = usePathname();
@@ -44,6 +45,9 @@ const Header = () => {
 
   const handleMenuClose = () => setIsMenuOpen(false);
 
+  const getIsActive = (href: string) =>
+    href === '/' ? pathname === '/' : pathname.startsWith(href);
+
   return (
     <header className={cn('sticky top-0 z-50 w-full bg-white')}>
       <div
@@ -61,28 +65,15 @@ const Header = () => {
         </Link>
 
         <nav className={cn('hidden items-center gap-12 lg:flex')}>
-          {links.map((link) => {
-            const isActive = link.href === '/' ? pathname === '/' : pathname.startsWith(link.href);
-
-            return (
-              <Link
-                key={link.href}
-                href={link.href}
-                className={cn(
-                  'relative flex flex-col items-center text-2xl leading-[120%] font-semibold transition-colors',
-                  isActive ? 'text-neutral-dark' : 'text-soft-gray hover:text-dark-utility',
-                )}
-              >
-                {link.label}
-                <span
-                  className={cn(
-                    'bg-brand-primary absolute -bottom-2 h-1 rounded-lg transition-[width] duration-300 ease-in-out',
-                    isActive ? 'w-5' : 'w-0',
-                  )}
-                />
-              </Link>
-            );
-          })}
+          {links.map((link) => (
+            <NavLink
+              key={link.href}
+              href={link.href}
+              label={link.label}
+              isActive={getIsActive(link.href)}
+              withHover
+            />
+          ))}
         </nav>
 
         <div className={cn('hidden items-center gap-4 lg:flex')}>
@@ -124,30 +115,15 @@ const Header = () => {
             )}
           >
             <div className={cn('flex flex-col items-end gap-12')}>
-              {links.map((link) => {
-                const isActive =
-                  link.href === '/' ? pathname === '/' : pathname.startsWith(link.href);
-
-                return (
-                  <Link
-                    key={link.href}
-                    href={link.href}
-                    onClick={handleMenuClose}
-                    className={cn(
-                      'relative flex flex-col items-center text-2xl leading-[120%] font-semibold transition-colors',
-                      isActive ? 'text-neutral-dark' : 'text-soft-gray',
-                    )}
-                  >
-                    {link.label}
-                    <span
-                      className={cn(
-                        'bg-brand-primary absolute -bottom-2 h-1 rounded-lg transition-[width] duration-300 ease-in-out',
-                        isActive ? 'w-5' : 'w-0',
-                      )}
-                    />
-                  </Link>
-                );
-              })}
+              {links.map((link) => (
+                <NavLink
+                  key={link.href}
+                  href={link.href}
+                  label={link.label}
+                  isActive={getIsActive(link.href)}
+                  onClick={handleMenuClose}
+                />
+              ))}
               {user ? (
                 <Button
                   onClick={() => {

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -23,7 +23,8 @@ const Header = () => {
   const pathname = usePathname();
   const router = useRouter();
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [menuOpenPathname, setMenuOpenPathname] = useState<string | null>(null);
+  const isMenuOpen = menuOpenPathname === pathname;
 
   const queryClient = useQueryClient();
   const { data: user } = useGetMyInfo();
@@ -43,7 +44,7 @@ const Header = () => {
     });
   };
 
-  const handleMenuClose = () => setIsMenuOpen(false);
+  const handleMenuClose = () => setMenuOpenPathname(null);
 
   const getIsActive = (href: string) =>
     href === '/' ? pathname === '/' : pathname.startsWith(href);
@@ -94,7 +95,7 @@ const Header = () => {
         </div>
 
         <button
-          onClick={() => setIsMenuOpen((prev) => !prev)}
+          onClick={() => setMenuOpenPathname(isMenuOpen ? null : pathname)}
           className={cn('flex items-center justify-center lg:hidden')}
           aria-label={isMenuOpen ? '메뉴 닫기' : '메뉴 열기'}
         >

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
@@ -43,6 +43,13 @@ const Header = () => {
       },
     });
   };
+
+  useEffect(() => {
+    document.body.style.overflow = isMenuOpen ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isMenuOpen]);
 
   const handleMenuClose = () => setMenuOpenPathname(null);
 

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -45,7 +45,7 @@ const Header = () => {
   const handleMenuClose = () => setIsMenuOpen(false);
 
   return (
-    <header className={cn('relative w-full bg-white')}>
+    <header className={cn('sticky top-0 z-50 w-full bg-white')}>
       <div
         className={cn(
           'mx-auto flex h-25 max-w-480 items-center justify-between',
@@ -112,13 +112,18 @@ const Header = () => {
       </div>
 
       {isMenuOpen && (
-        <div
-          className={cn(
-            'border-border-variant absolute top-full left-0 z-50 w-full border-t bg-white lg:hidden',
-          )}
-        >
-          <div className={cn('mx-auto flex max-w-480 flex-col px-8 py-6')}>
-            <nav className={cn('flex flex-col gap-6')}>
+        <>
+          <div
+            className={cn('fixed inset-x-0 top-25 bottom-0 z-40 lg:hidden')}
+            onClick={handleMenuClose}
+          />
+          <div
+            className={cn(
+              'fixed top-25 right-0 bottom-0 z-40 bg-white lg:hidden',
+              'inline-flex flex-col items-end pt-9 pr-6 pb-34.25 pl-12.75',
+            )}
+          >
+            <div className={cn('flex flex-col items-end gap-12')}>
               {links.map((link) => {
                 const isActive =
                   link.href === '/' ? pathname === '/' : pathname.startsWith(link.href);
@@ -129,17 +134,20 @@ const Header = () => {
                     href={link.href}
                     onClick={handleMenuClose}
                     className={cn(
-                      'text-2xl leading-[120%] font-semibold transition-colors',
+                      'relative flex flex-col items-center text-2xl leading-[120%] font-semibold transition-colors',
                       isActive ? 'text-neutral-dark' : 'text-soft-gray',
                     )}
                   >
                     {link.label}
+                    <span
+                      className={cn(
+                        'bg-brand-primary absolute -bottom-2 h-1 rounded-lg transition-[width] duration-300 ease-in-out',
+                        isActive ? 'w-5' : 'w-0',
+                      )}
+                    />
                   </Link>
                 );
               })}
-            </nav>
-
-            <div className={cn('mt-8 flex flex-col gap-3')}>
               {user ? (
                 <Button
                   onClick={() => {
@@ -174,7 +182,7 @@ const Header = () => {
               )}
             </div>
           </div>
-        </div>
+        </>
       )}
 
       <LoginModal isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />

--- a/src/widgets/header/ui/NavLink.tsx
+++ b/src/widgets/header/ui/NavLink.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+
+import { cn } from '@/shared/lib';
+
+interface NavLinkProps {
+  href: string;
+  label: string;
+  isActive: boolean;
+  onClick?: () => void;
+  withHover?: boolean;
+}
+
+const NavLink = ({ href, label, isActive, onClick, withHover = false }: NavLinkProps) => (
+  <Link
+    href={href}
+    onClick={onClick}
+    className={cn(
+      'relative flex flex-col items-center text-2xl leading-[120%] font-semibold transition-colors',
+      isActive ? 'text-neutral-dark' : cn('text-soft-gray', withHover && 'hover:text-dark-utility'),
+    )}
+  >
+    {label}
+    <span
+      className={cn(
+        'bg-brand-primary absolute -bottom-2 h-1 rounded-lg transition-[width] duration-300 ease-in-out',
+        isActive ? 'w-5' : 'w-0',
+      )}
+    />
+  </Link>
+);
+
+export default NavLink;


### PR DESCRIPTION
## 개요 💡

모바일 환경에서의 헤더와 푸터 반응형 레이아웃을 구현했습니다.
햄버거 메뉴를 Figma 디자인에 맞는 오른쪽 드로어 패널로 개선하고, 헤더를 sticky로 고정했습니다.

## 작업내용 ⌨️

**헤더**
- 모바일 햄버거 메뉴 버튼 추가 (`lg` 미만에서 표시)
- 기존 전체 너비 드롭다운 → 오른쪽 슬라이드 드로어 패널로 변경
- 드로어 외부 클릭 시 메뉴 닫힘 처리
- 헤더를 `sticky top-0`으로 고정 (스크롤 시 항상 노출)
- 활성 링크에 데스크탑과 동일한 파란 underline indicator 적용
- `NavLink` 컴포넌트 분리로 데스크탑/모바일 링크 렌더링 중복 제거 (FSD: `widgets/header/ui/NavLink.tsx`)

**푸터**
- 모바일 반응형 레이아웃 적용
- 색상을 CSS 변수로 교체


## 스크린샷/동영상 📸

https://github.com/user-attachments/assets/b2adaca5-c49d-4927-a228-05b5ee97c5ea



## 관련 이슈 🚨

https://github.com/themoment-team/ReadyGSM-client/issues/51


