### PR TITLE
[hotfix] sharp linux 빌드 설정 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-dom": "19.2.4",
     "react-hook-form": "^7.71.2",
     "react-toastify": "^11.1.0",
+    "sharp": "^0.34.5",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       react-toastify:
         specifier: ^11.1.0
         version: 11.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -2496,8 +2499,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.0.0':
-    optional: true
+  '@img/colour@1.0.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -4277,7 +4279,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
## 개요 💡
Next.js 이미지 최적화에 필요한 sharp 패키지가 Linux 빌드 환경(Vercel 등)에서 optional로 처리되어 설치되지 않아 빌드가 실패하는 문제를 수정합니다.

## 작업내용 ⌨️
sharp 패키지를 dependencies에 명시적으로 추가 (^0.34.5)
pnpm-lock.yaml에서 @img/colour 및 sharp의 optional: true 제거 → Linux 빌드 시 필수 설치되도록 변경
## 관련 이슈 🚨
Vercel(Linux) 환경에서 sharp 미설치로 인한 빌드 실패