### PR TITLE
[hotfix] Server Component auth fetch를 Next.js proxy 경유로 변경

### DIFF
--- a/src/entities/application/api/getMyApplication.ts
+++ b/src/entities/application/api/getMyApplication.ts
@@ -1,4 +1,4 @@
-import { cookies } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 
 import { type ApiResponseType, applicationUrl } from '@/shared/api';
 
@@ -7,8 +7,11 @@ import type { ApplicationType } from '../model/types';
 const getMyApplication = async (userId: number): Promise<ApplicationType | undefined> => {
   try {
     const cookieStore = await cookies();
+    const headerStore = await headers();
+    const host = headerStore.get('host');
+    const proto = headerStore.get('x-forwarded-proto') ?? 'http';
     const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}${applicationUrl.getMyApplication()}?userId=${userId}`,
+      `${proto}://${host}/api${applicationUrl.getMyApplication()}?userId=${userId}`,
       {
         headers: { Cookie: cookieStore.toString() },
         cache: 'no-store',

--- a/src/entities/user/api/getMyInfo.ts
+++ b/src/entities/user/api/getMyInfo.ts
@@ -1,4 +1,4 @@
-import { cookies } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 
 import { type ApiResponseType, userUrl } from '@/shared/api';
 
@@ -7,7 +7,10 @@ import type { UserType } from '../model/types';
 const getMyInfo = async (): Promise<UserType | undefined> => {
   try {
     const cookieStore = await cookies();
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}${userUrl.getMyInfo()}`, {
+    const headerStore = await headers();
+    const host = headerStore.get('host');
+    const proto = headerStore.get('x-forwarded-proto') ?? 'http';
+    const res = await fetch(`${proto}://${host}/api${userUrl.getMyInfo()}`, {
       headers: { Cookie: cookieStore.toString() },
       cache: 'no-store',
     });


### PR DESCRIPTION
## 개요 💡
프로덕션(HTTPS) 환경에서 학과체험 신청·조회 페이지 진입 시 로그인 상태임에도 "로그인이 필요한 기능입니다"가 표시되는 버그 수정.

Server Component에서 백엔드를 직접 호출할 때 HTTPS + Secure 쿠키 조합으로 인증이 실패하여 isLoggedIn = false로 처리되던 것이 원인.

## 작업내용 ⌨️
getMyInfo, getMyApplication에서 NEXT_PUBLIC_API_BASE_URL 직접 호출 대신 headers()로 host/proto를 읽어 Next.js proxy(/api/v1/...)를 경유하도록 변경