### PR TITLE
[hotfix] 토스트 닫기 버튼 미동작 및 호버 시 자동닫힘 정지 문제 수정 

### DIFF
--- a/src/shared/assets/toast/CloseIcon.tsx
+++ b/src/shared/assets/toast/CloseIcon.tsx
@@ -6,6 +6,9 @@ interface CloseIconProps {
 
 const CloseIcon = ({ closeToast }: CloseIconProps) => (
   <svg
+    role="button"
+    tabIndex={0}
+    aria-label="닫기"
     width="1.5rem"
     height="1.5rem"
     viewBox="0 0 24 24"
@@ -15,6 +18,13 @@ const CloseIcon = ({ closeToast }: CloseIconProps) => (
     onClick={(event) => {
       event.stopPropagation();
       closeToast?.(true);
+    }}
+    onKeyDown={(event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        event.stopPropagation();
+        closeToast?.(true);
+      }
     }}
   >
     <path

--- a/src/shared/assets/toast/CloseIcon.tsx
+++ b/src/shared/assets/toast/CloseIcon.tsx
@@ -1,13 +1,21 @@
 import { cn } from '@/shared/lib';
 
-const CloseIcon = () => (
+interface CloseIconProps {
+  closeToast?: (dismiss?: boolean) => void;
+}
+
+const CloseIcon = ({ closeToast }: CloseIconProps) => (
   <svg
     width="1.5rem"
     height="1.5rem"
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
-    className={cn('Toastify__Close-Button')}
+    className={cn('Toastify__Close-Button', 'cursor-pointer')}
+    onClick={(event) => {
+      event.stopPropagation();
+      closeToast?.(true);
+    }}
   >
     <path
       d="M6 18L18 6M6 6L18 18"

--- a/src/shared/lib/ToastProvider.tsx
+++ b/src/shared/lib/ToastProvider.tsx
@@ -17,6 +17,7 @@ const ToastProvider = () => (
     position="top-right"
     icon={({ type }) => <InfoIcon fill={ICON_FILL_BY_TYPE[type] ?? '#16A34A'} />}
     closeButton={<CloseIcon />}
+    pauseOnHover={false}
   />
 );
 


### PR DESCRIPTION
## 개요 💡

토스트 알림의 닫기 버튼이 동작하지 않고, 마우스 호버 시 자동 닫힘이 멈추는 문제를 수정합니다.

## 작업내용 ⌨️

- `CloseIcon`에 `closeToast` prop을 받아 클릭 시 호출하도록 수정 → X 버튼 클릭 시 토스트가 정상적으로 닫힘
- `ToastProvider`에 `pauseOnHover={false}` 설정 → 토스트에 마우스를 올려도 자동 닫힘 타이머가 멈추지 않음

## 관련 이슈 🚨

https://github.com/themoment-team/readygsm-client/issues/66


