### PR TITLE
[fix] 학과 체험 생성/수정 시 접수 기간 정보 누락 수정

### DIFF
--- a/src/app/admin/form/page.tsx
+++ b/src/app/admin/form/page.tsx
@@ -4,8 +4,21 @@ import { ActivityFormView } from '@/features/manageActivity';
 const AdminFormPage = async () => {
   const response = await getActivityList();
   const isFirstActivity = !response?.data?.length;
+  const firstActivity = response?.data?.[0];
+  const registrationPeriod = firstActivity
+    ? {
+        registrationStartAt: firstActivity.registrationStartAt,
+        registrationEndAt: firstActivity.registrationEndAt,
+      }
+    : undefined;
 
-  return <ActivityFormView mode="create" isFirstActivity={isFirstActivity} />;
+  return (
+    <ActivityFormView
+      mode="create"
+      isFirstActivity={isFirstActivity}
+      registrationPeriod={registrationPeriod}
+    />
+  );
 };
 
 export default AdminFormPage;

--- a/src/app/admin/form/page.tsx
+++ b/src/app/admin/form/page.tsx
@@ -3,8 +3,11 @@ import { ActivityFormView } from '@/features/manageActivity';
 
 const AdminFormPage = async () => {
   const response = await getActivityList();
-  const isFirstActivity = !response?.data?.length;
-  const firstActivity = response?.data?.[0];
+
+  if (!response) throw new Error('학과 체험 목록을 불러오는데 실패했습니다.');
+
+  const isFirstActivity = !response.data?.length;
+  const firstActivity = response.data?.[0];
   const registrationPeriod = firstActivity
     ? {
         registrationStartAt: firstActivity.registrationStartAt,

--- a/src/features/manageActivity/model/types.ts
+++ b/src/features/manageActivity/model/types.ts
@@ -41,12 +41,13 @@ const toBaseFields = (values: ActivityBaseFormType) => ({
   activityEndTime: `${pad(values.activityEndHour)}:${pad(values.activityEndMinute)}`,
 });
 
-export const toActivityBaseReqDto = (values: ActivityBaseFormType) => toBaseFields(values);
-
-export const toActivityPatchReqDto = (values: ActivityBaseFormType, activity: ActivityType) => ({
+export const toActivityWithRegistrationReqDto = (
+  values: ActivityBaseFormType,
+  registration: Pick<ActivityType, 'registrationStartAt' | 'registrationEndAt'>,
+) => ({
   ...toBaseFields(values),
-  registrationStartAt: activity.registrationStartAt,
-  registrationEndAt: activity.registrationEndAt,
+  registrationStartAt: registration.registrationStartAt,
+  registrationEndAt: registration.registrationEndAt,
 });
 
 export const toActivityFirstCreateReqDto = (values: ActivityFirstCreateFormType) => {

--- a/src/features/manageActivity/model/types.ts
+++ b/src/features/manageActivity/model/types.ts
@@ -43,6 +43,12 @@ const toBaseFields = (values: ActivityBaseFormType) => ({
 
 export const toActivityBaseReqDto = (values: ActivityBaseFormType) => toBaseFields(values);
 
+export const toActivityPatchReqDto = (values: ActivityBaseFormType, activity: ActivityType) => ({
+  ...toBaseFields(values),
+  registrationStartAt: activity.registrationStartAt,
+  registrationEndAt: activity.registrationEndAt,
+});
+
 export const toActivityFirstCreateReqDto = (values: ActivityFirstCreateFormType) => {
   const currentYear = new Date().getFullYear();
   return {

--- a/src/features/manageActivity/model/usePatchActivity.ts
+++ b/src/features/manageActivity/model/usePatchActivity.ts
@@ -4,9 +4,9 @@ import { revalidateActivityList } from '@/entities/activity/api/revalidateActivi
 import { activityQueryKeys } from '@/entities/activity/model/useGetActivityList';
 import { activityUrl, patch } from '@/shared/api';
 
-import type { toActivityBaseReqDto } from './types';
+import type { toActivityPatchReqDto } from './types';
 
-type ActivityReqDto = ReturnType<typeof toActivityBaseReqDto>;
+type ActivityReqDto = ReturnType<typeof toActivityPatchReqDto>;
 
 const usePatchActivityMutation = (id: number) => {
   const queryClient = useQueryClient();

--- a/src/features/manageActivity/model/usePatchActivity.ts
+++ b/src/features/manageActivity/model/usePatchActivity.ts
@@ -4,9 +4,9 @@ import { revalidateActivityList } from '@/entities/activity/api/revalidateActivi
 import { activityQueryKeys } from '@/entities/activity/model/useGetActivityList';
 import { activityUrl, patch } from '@/shared/api';
 
-import type { toActivityPatchReqDto } from './types';
+import type { toActivityWithRegistrationReqDto } from './types';
 
-type ActivityReqDto = ReturnType<typeof toActivityPatchReqDto>;
+type ActivityReqDto = ReturnType<typeof toActivityWithRegistrationReqDto>;
 
 const usePatchActivityMutation = (id: number) => {
   const queryClient = useQueryClient();

--- a/src/features/manageActivity/model/usePostActivity.ts
+++ b/src/features/manageActivity/model/usePostActivity.ts
@@ -4,11 +4,11 @@ import { revalidateActivityList } from '@/entities/activity/api/revalidateActivi
 import { activityQueryKeys } from '@/entities/activity/model/useGetActivityList';
 import { activityUrl, post } from '@/shared/api';
 
-import type { toActivityBaseReqDto, toActivityFirstCreateReqDto } from './types';
+import type { toActivityFirstCreateReqDto, toActivityWithRegistrationReqDto } from './types';
 
 type ActivityReqDto =
   | ReturnType<typeof toActivityFirstCreateReqDto>
-  | ReturnType<typeof toActivityBaseReqDto>;
+  | ReturnType<typeof toActivityWithRegistrationReqDto>;
 
 const usePostActivityMutation = () => {
   const queryClient = useQueryClient();

--- a/src/features/manageActivity/ui/ActivityFormView.tsx
+++ b/src/features/manageActivity/ui/ActivityFormView.tsx
@@ -28,6 +28,7 @@ import {
   type ActivityFirstCreateFormType,
   toActivityBaseReqDto,
   toActivityFirstCreateReqDto,
+  toActivityPatchReqDto,
   toFormValues,
 } from '../model/types';
 import { usePatchActivity } from '../model/usePatchActivity';
@@ -75,8 +76,8 @@ const ActivityFormView = ({ mode, activity, isFirstActivity }: ActivityFormViewP
   const handleBaseSubmit = (values: ActivityBaseFormType) => {
     if (mode === 'create') {
       postActivity(toActivityBaseReqDto(values), { onSuccess: handleSuccess });
-    } else {
-      patchActivity(toActivityBaseReqDto(values), { onSuccess: handleSuccess });
+    } else if (activity) {
+      patchActivity(toActivityPatchReqDto(values, activity), { onSuccess: handleSuccess });
     }
   };
 

--- a/src/features/manageActivity/ui/ActivityFormView.tsx
+++ b/src/features/manageActivity/ui/ActivityFormView.tsx
@@ -26,9 +26,8 @@ import {
   type ActivityBaseFormType,
   ActivityFirstCreateFormSchema,
   type ActivityFirstCreateFormType,
-  toActivityBaseReqDto,
   toActivityFirstCreateReqDto,
-  toActivityPatchReqDto,
+  toActivityWithRegistrationReqDto,
   toFormValues,
 } from '../model/types';
 import { usePatchActivity } from '../model/usePatchActivity';
@@ -38,6 +37,7 @@ interface ActivityFormViewProps {
   mode: 'create' | 'edit';
   activity?: ActivityType;
   isFirstActivity?: boolean;
+  registrationPeriod?: Pick<ActivityType, 'registrationStartAt' | 'registrationEndAt'>;
 }
 
 const CURRENT_YEAR = new Date().getFullYear();
@@ -45,7 +45,12 @@ const YEARS = Array.from({ length: 5 }, (_, i) => CURRENT_YEAR + i - 1);
 const MONTHS = Array.from({ length: 12 }, (_, i) => i + 1);
 const DAYS = Array.from({ length: 31 }, (_, i) => i + 1);
 
-const ActivityFormView = ({ mode, activity, isFirstActivity }: ActivityFormViewProps) => {
+const ActivityFormView = ({
+  mode,
+  activity,
+  isFirstActivity,
+  registrationPeriod,
+}: ActivityFormViewProps) => {
   const router = useRouter();
   const { postActivity, isPending: isCreating } = usePostActivity();
   const { patchActivity, isPending: isEditing } = usePatchActivity(activity?.id ?? 0);
@@ -74,10 +79,14 @@ const ActivityFormView = ({ mode, activity, isFirstActivity }: ActivityFormViewP
   };
 
   const handleBaseSubmit = (values: ActivityBaseFormType) => {
-    if (mode === 'create') {
-      postActivity(toActivityBaseReqDto(values), { onSuccess: handleSuccess });
+    if (mode === 'create' && registrationPeriod) {
+      postActivity(toActivityWithRegistrationReqDto(values, registrationPeriod), {
+        onSuccess: handleSuccess,
+      });
     } else if (activity) {
-      patchActivity(toActivityPatchReqDto(values, activity), { onSuccess: handleSuccess });
+      patchActivity(toActivityWithRegistrationReqDto(values, activity), {
+        onSuccess: handleSuccess,
+      });
     }
   };
 


### PR DESCRIPTION
## 개요 💡

두 번째 이후 학과 체험 생성(POST) 및 기존 학과 체험 수정(PATCH) 시
`registrationStartAt`, `registrationEndAt`(접수 시작/종료일)이 요청에 포함되지
않아 서버 오류가 발생하던 문제를 수정합니다.

## 작업내용 ⌨️

- 두 번째 이후 활동 생성 시, `getActivityList()`로 가져온 기존 활동의 첫 번째 항목에서 접수 기간 값을 추출해 POST payload에 포함
- 활동 수정(PATCH) 시, 이미 서버에서 받아온 `activity` prop의 접수 기간 값을 PATCH payload에 포함
- `toActivityBaseReqDto`, `toActivityPatchReqDto`를 `toActivityWithRegistrationReqDto`로 통합 (CREATE/PATCH 공통 사용)
- `ActivityFormView`에 `registrationPeriod` prop 추가, `src/app/admin/form/page.tsx`에서 전달

## 관련 이슈 🚨

close #68