### PR TITLE
[hotfix] 학과체험 카드에 예비 신청 안내 문구 추가

### DIFF
--- a/src/entities/application/model/types.ts
+++ b/src/entities/application/model/types.ts
@@ -9,6 +9,7 @@ export interface ApplicationType {
   schoolName: string;
   phoneNumber: string;
   familyPhoneNumber: string;
+  isReserve: boolean;
 }
 
 export interface PostApplicationRequestType {

--- a/src/entities/program/ui/ProgramCard.tsx
+++ b/src/entities/program/ui/ProgramCard.tsx
@@ -61,6 +61,12 @@ const ProgramCard = ({
       <p className={cn('text-secondary-slate mt-2 text-[0.875rem] leading-[1.4] font-normal')}>
         {activityDate}
       </p>
+
+      {reservePersonnel <= 0 && (
+        <p className={cn('text-error-red mt-2 text-[0.875rem] leading-[1.4] font-normal')}>
+          예비 신청의 경우, 신청이 확정되지 않으면 확정 안내 문자가 발송되지 않을 수 있습니다.
+        </p>
+      )}
     </section>
   );
 };

--- a/src/entities/program/ui/ProgramCard.tsx
+++ b/src/entities/program/ui/ProgramCard.tsx
@@ -6,6 +6,7 @@ interface ProgramCardProps extends Pick<
   'name' | 'description' | 'activityDate' | 'maxApplicant' | 'currentApplicant'
 > {
   isSelected?: boolean | undefined;
+  isReserved?: boolean;
   disableHover?: boolean;
   onClick?: () => void;
 }
@@ -17,10 +18,12 @@ const ProgramCard = ({
   maxApplicant,
   currentApplicant,
   isSelected,
+  isReserved,
   disableHover = false,
   onClick,
 }: ProgramCardProps) => {
   const reservePersonnel = maxApplicant - currentApplicant;
+  const showReserveWarning = isReserved !== undefined ? isReserved : reservePersonnel <= 0;
 
   return (
     <section
@@ -50,7 +53,7 @@ const ProgramCard = ({
             isSelected ? 'text-[#2563EB]' : 'text-neutral-dark',
           )}
         >
-          {reservePersonnel > 0 ? `${currentApplicant}/${maxApplicant}` : '예비 신청'}
+          {showReserveWarning ? '예비 신청' : `${currentApplicant}/${maxApplicant}`}
         </p>
       </header>
 
@@ -62,7 +65,7 @@ const ProgramCard = ({
         {activityDate}
       </p>
 
-      {reservePersonnel <= 0 && (
+      {showReserveWarning && (
         <p className={cn('text-error-red mt-2 text-[0.875rem] leading-[1.4] font-normal')}>
           예비 신청의 경우, 신청이 확정되지 않으면 확정 안내 문자가 발송되지 않을 수 있습니다.
         </p>

--- a/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
+++ b/src/widgets/applicantManagement/ui/ApplicantManagementTable.tsx
@@ -24,7 +24,8 @@ const formatStudentId = ({ grade, classNumber, number }: ApplicationType) =>
 const ApplicantManagementTable = ({ activityId }: ApplicantManagementTableProps) => {
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
-  const { data: applications = [] } = useGetAdminApplications(activityId);
+  const { data: allApplications = [] } = useGetAdminApplications(activityId);
+  const applications = allApplications.filter((a) => !a.isReserve);
   const { data: activityList } = useGetActivityList();
   const activities = activityList?.data ?? [];
   const { mutate: deleteApplication, isPending } = useDeleteApplicant();

--- a/src/widgets/applicationSection/ui/ApplicationSection.tsx
+++ b/src/widgets/applicationSection/ui/ApplicationSection.tsx
@@ -56,6 +56,7 @@ const ApplicationSection = ({ user, application, activity }: ApplicationSectionP
               activityDate={activity.activityDate}
               maxApplicant={activity.maxApplicant}
               currentApplicant={activity.currentApplicant}
+              isReserved={application.isReserve}
               disableHover
             />
           </section>


### PR DESCRIPTION
## 개요 💡

예비 신청 상태(정원 초과)인 학과체험 카드에서 신청이 확정되지 않을 수 있음을 사용자에게 명확히 안내하기 위해 안내 문구를 추가합니다.

## 작업내용 ⌨️

- \`ProgramCard\` 컴포넌트에 예비 신청 상태(\`currentApplicant >= maxApplicant\`)일 때 날짜 아래 빨간색(\`text-error-red\`) 안내 문구 추가
  - "예비 신청의 경우, 신청이 확정되지 않으면 확정 안내 문자가 발송되지 않을 수 있습니다."
- 학과체험 신청 목록 화면과 내 신청 정보 조회 화면 모두에 적용됨