### PR TITLE
[hotfix] 학과체험 신청/취소/삭제 후 인원 수 미반영 문제 수정

### DIFF
--- a/src/entities/activity/index.ts
+++ b/src/entities/activity/index.ts
@@ -1,6 +1,7 @@
 export { default as getActivityById } from './api/getActivityById';
 export { default as getActivityList } from './api/getActivityList';
+export { revalidateActivityList } from './api/revalidateActivityList';
 export type { ActivityListResponseType, ActivityType } from './model/types';
 export { default as useGetActivityById } from './model/useGetActivityById';
-export { default as useGetActivityList } from './model/useGetActivityList';
+export { activityQueryKeys, default as useGetActivityList } from './model/useGetActivityList';
 export { default as ActivityCard } from './ui/ActivityCard';

--- a/src/features/applyDepartment/model/useApplicationForm.ts
+++ b/src/features/applyDepartment/model/useApplicationForm.ts
@@ -1,15 +1,18 @@
 import { useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
 
+import { activityQueryKeys, revalidateActivityList } from '@/entities/activity';
 import { usePostApplication } from '@/entities/application';
 
 import { ApplicationFormSchema, type ApplicationFormType } from './schema';
 
 export const useApplicationForm = (activityId: number, userId: number, onSuccess?: () => void) => {
   const [isSchoolModalOpen, setIsSchoolModalOpen] = useState(false);
+  const queryClient = useQueryClient();
   const { mutate: postApplication } = usePostApplication();
 
   const form = useForm<ApplicationFormType>({
@@ -45,6 +48,8 @@ export const useApplicationForm = (activityId: number, userId: number, onSuccess
       },
       {
         onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: activityQueryKeys.getActivityList() });
+          revalidateActivityList();
           toast.success('학과 체험 신청이 완료되었습니다.');
           onSuccess?.();
         },

--- a/src/features/applyDepartment/model/useApplicationForm.ts
+++ b/src/features/applyDepartment/model/useApplicationForm.ts
@@ -47,9 +47,9 @@ export const useApplicationForm = (activityId: number, userId: number, onSuccess
         familyPhoneNumber: data.guardianPhone,
       },
       {
-        onSuccess: () => {
+        onSuccess: async () => {
           queryClient.invalidateQueries({ queryKey: activityQueryKeys.getActivityList() });
-          revalidateActivityList();
+          await revalidateActivityList();
           toast.success('학과 체험 신청이 완료되었습니다.');
           onSuccess?.();
         },

--- a/src/features/cancelApply/model/useCancelApply.ts
+++ b/src/features/cancelApply/model/useCancelApply.ts
@@ -1,15 +1,22 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { activityQueryKeys, revalidateActivityList } from '@/entities/activity';
 import { del } from '@/shared/api';
 
 export const cancelApplyUrl = {
   deleteApply: () => '/v1/application/cancel',
 } as const;
 
-const useDeleteApply = (userId: number, activityId: number) =>
-  useMutation({
+const useDeleteApply = (userId: number, activityId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
     mutationFn: () => del(cancelApplyUrl.deleteApply(), { params: { userId, activityId } }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: activityQueryKeys.getActivityList() });
+      revalidateActivityList();
+    },
   });
+};
 
 export const useCancelApply = (userId: number, activityId: number) => {
   const { mutate: cancelApply, isPending } = useDeleteApply(userId, activityId);

--- a/src/features/cancelApply/model/useCancelApply.ts
+++ b/src/features/cancelApply/model/useCancelApply.ts
@@ -11,9 +11,9 @@ const useDeleteApply = (userId: number, activityId: number) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: () => del(cancelApplyUrl.deleteApply(), { params: { userId, activityId } }),
-    onSuccess: () => {
+    onSuccess: async () => {
       queryClient.invalidateQueries({ queryKey: activityQueryKeys.getActivityList() });
-      revalidateActivityList();
+      await revalidateActivityList();
     },
   });
 };

--- a/src/features/manageApplicant/model/useDeleteApplicant.ts
+++ b/src/features/manageApplicant/model/useDeleteApplicant.ts
@@ -9,10 +9,10 @@ export const useDeleteApplicant = () => {
 
   return useMutation({
     mutationFn: (id: number) => del<void>(applicationUrl.deleteApplication(id)),
-    onSuccess: () => {
+    onSuccess: async () => {
       queryClient.invalidateQueries({ queryKey: applicationQueryKeys.allAdminApplications() });
       queryClient.invalidateQueries({ queryKey: activityQueryKeys.getActivityList() });
-      revalidateActivityList();
+      await revalidateActivityList();
     },
   });
 };

--- a/src/features/manageApplicant/model/useDeleteApplicant.ts
+++ b/src/features/manageApplicant/model/useDeleteApplicant.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { activityQueryKeys, revalidateActivityList } from '@/entities/activity';
 import { applicationQueryKeys } from '@/entities/application';
 import { applicationUrl, del } from '@/shared/api';
 
@@ -9,9 +10,9 @@ export const useDeleteApplicant = () => {
   return useMutation({
     mutationFn: (id: number) => del<void>(applicationUrl.deleteApplication(id)),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: applicationQueryKeys.allAdminApplications(),
-      });
+      queryClient.invalidateQueries({ queryKey: applicationQueryKeys.allAdminApplications() });
+      queryClient.invalidateQueries({ queryKey: activityQueryKeys.getActivityList() });
+      revalidateActivityList();
     },
   });
 };


### PR DESCRIPTION
## 개요 💡

학과체험 신청/취소/어드민 삭제 후 각 학과체험의 신청 인원(`currentApplicant`)이 즉시 반영되지 않고, 새로고침해도 이전 값이 그대로 유지되는 문제를 수정합니다.

**원인:**
- 신청/취소/삭제 mutation 성공 후 Next.js ISR 캐시(`activity-list` 태그, `revalidate: 3600`)를 무효화하는 코드가 없어 새로고침해도 최대 1시간 동안 이전 인원 수 유지
- 클라이언트 React Query 캐시(`['activity', 'list']`)도 invalidate되지 않아 어드민 화면에서도 인원 수 미반영

## 작업내용 ⌨️

- `entities/activity/index.ts` — `activityQueryKeys`, `revalidateActivityList` 배럴 export 추가
- `features/applyDepartment/model/useApplicationForm.ts` — 신청 성공 시 `invalidateQueries` + `revalidateActivityList()` 추가
- `features/cancelApply/model/useCancelApply.ts` — 취소 성공 시 `invalidateQueries` + `revalidateActivityList()` 추가
- `features/manageApplicant/model/useDeleteApplicant.ts` — 어드민 신청자 삭제 성공 시 activity 캐시 invalidation + `revalidateActivityList()` 추가

## 관련 이슈 🚨
#67 