### PR TITLE
[fix] CloseIcon closeToast 타입 및 인자 수정

### DIFF
--- a/src/shared/assets/toast/CloseIcon.tsx
+++ b/src/shared/assets/toast/CloseIcon.tsx
@@ -1,4 +1,4 @@
-import { SyntheticEvent } from 'react';
+import type { SyntheticEvent } from 'react';
 
 import { cn } from '@/shared/lib';
 

--- a/src/shared/assets/toast/CloseIcon.tsx
+++ b/src/shared/assets/toast/CloseIcon.tsx
@@ -1,7 +1,9 @@
+import { SyntheticEvent } from 'react';
+
 import { cn } from '@/shared/lib';
 
 interface CloseIconProps {
-  closeToast?: (dismiss?: boolean) => void;
+  closeToast?: (e: SyntheticEvent) => void;
 }
 
 const CloseIcon = ({ closeToast }: CloseIconProps) => (
@@ -17,13 +19,13 @@ const CloseIcon = ({ closeToast }: CloseIconProps) => (
     className={cn('Toastify__Close-Button', 'cursor-pointer')}
     onClick={(event) => {
       event.stopPropagation();
-      closeToast?.(true);
+      closeToast?.(event);
     }}
     onKeyDown={(event) => {
       if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault();
         event.stopPropagation();
-        closeToast?.(true);
+        closeToast?.(event);
       }
     }}
   >


### PR DESCRIPTION
## 개요 💡

`react-toastify`의 커스텀 닫기 버튼 컴포넌트인 `CloseIcon`에서 `closeToast` prop의 타입과 호출 인자가 잘못 정의되어 있던 버그를 수정합니다.

## 작업내용 ⌨️

- `CloseIconProps`의 `closeToast` 타입을 `(dismiss?: boolean) => void`에서 `(e: SyntheticEvent) => void`로 수정
- `onClick`, `onKeyDown` 핸들러에서 `closeToast?.(true)` → `closeToast?.(event)`로 변경
- `SyntheticEvent` import 추가

`react-toastify`는 커스텀 closeButton에 주입하는 `closeToast` 함수 내부에서 `e.stopPropagation()`을 호출합니다. 
기존 코드처럼 `true`를 넘기면 `TypeError: e.stopPropagation is not a function` 런타임 에러가 발생해 토스트가 정상적으로 닫히지 않는 문제가 있었습니다.
