### PR TITLE
[fix] 학과체험 신청 페이지 고정 높이로 인한 UI 잘림 수정

### DIFF
--- a/src/views/programs/ui/ProgramsPage.tsx
+++ b/src/views/programs/ui/ProgramsPage.tsx
@@ -40,7 +40,7 @@ const ProgramsPage = ({ activities, isLoggedIn, application, userId }: ProgramsP
   return (
     <div
       className={cn(
-        'mx-auto flex w-155.5 flex-col gap-9 py-9 xl:h-[calc(100vh-6.25rem)] xl:w-7xl xl:flex-row xl:justify-center',
+        'mx-auto flex w-155.5 flex-col gap-9 py-9 xl:min-h-[calc(100vh-6.25rem)] xl:w-7xl xl:flex-row xl:justify-center',
       )}
     >
       <div className={cn('flex flex-col gap-5')}>


### PR DESCRIPTION
## 개요 💡

학과체험 신청 페이지(`/programs`)에서 1440px(xl) 이상 너비일 때 보호자 관계를 "기타"로 선택하면 추가 입력 필드가 렌더링되면서 콘텐츠가 늘어나는데, 이때 페이지 하단이 푸터 아래로 잘려 보이는 문제가 있었습니다. 원인은 `ProgramsPage`의 최상위 컨테이너가 `xl:h-[calc(100vh-6.25rem)]`로 **고정 높이**를 갖고 있어, 내부 콘텐츠가 늘어나도 컨테이너가 함께 자라지 못했기 때문입니다.

## 작업내용 ⌨️

- `src/views/programs/ui/ProgramsPage.tsx`의 `xl:h-[calc(100vh-6.25rem)]`를 `xl:min-h-[calc(100vh-6.25rem)]`로 변경
- 동일한 `calc(100vh-...)` 패턴을 사용하는 다른 컴포넌트(`ApplicationSection`, `CompletionMessage`)와 동일하게 `min-h-`를 사용하여 콘텐츠 양에 따라 컨테이너가 함께 늘어나도록 수정

## 관련 이슈 🚨

close #71