### PR TITLE
[fix] 학과체험 등록 후 목록 페이지에 즉시 반영되지 않는 문제 수정

### DIFF
--- a/src/entities/activity/api/revalidateActivityList.ts
+++ b/src/entities/activity/api/revalidateActivityList.ts
@@ -1,7 +1,7 @@
 'use server';
 
-import { revalidateTag } from 'next/cache';
+import { updateTag } from 'next/cache';
 
 export const revalidateActivityList = async () => {
-  revalidateTag('activity-list', 'default');
+  updateTag('activity-list');
 };


### PR DESCRIPTION
## 개요 💡

어드민 페이지에서 학과체험을 등록한 후 학과체험 목록 페이지로 이동하면, Vercel 배포 환경에서 새로 추가된 항목이 즉시 표시되지 않고 새로고침을 해야 보이는 문제가 있었습니다.

## 작업내용 ⌨️

**원인**

`revalidateActivityList` Server Action에서 `revalidateTag('activity-list', 'default')`를 사용하고 있었는데, `'default'` 프로필을 인자로 넘기면 Next.js 내부에서 `pathWasRevalidated`가 `ActionDidRevalidateStaticAndDynamic`으로 설정되지 않습니다.

이로 인해 캐시 태그 자체는 만료 예약이 되지만, App Router가 클라이언트에 정적/동적 콘텐츠 갱신 신호를 보내지 않아 router refresh가 발생하지 않았습니다.

로컬 개발 환경은 fetch 캐시가 약하게 동작하여 차이가 없었지만, Vercel에서는 `next: { revalidate: 3600, tags: ['activity-list'] }` 캐시가 실제로 적용되기 때문에 문제가 드러났습니다.

**수정**

`revalidateTag('activity-list', 'default')` → `updateTag('activity-list')`로 교체

`updateTag`는 Server Action 전용 API로, profile 없이 즉시 만료(`undefined` profile) 처리가 되어 `pathWasRevalidated = ActionDidRevalidateStaticAndDynamic`이 올바르게 설정됩니다.

```ts
// before
revalidateTag('activity-list', 'default');

// after
updateTag('activity-list');
```

## 관련 이슈 🚨
https://github.com/themoment-team/readygsm-client/issues/81
- Vercel 배포 환경에서만 재현되는 캐시 갱신 버그