### PR TITLE
[fix] 학과 체험 신청 기간 아닐 때 안내 문구 추가

### DIFF
--- a/src/views/programs/ui/ProgramsPage.tsx
+++ b/src/views/programs/ui/ProgramsPage.tsx
@@ -19,6 +19,15 @@ const ProgramsPage = ({ activities, isLoggedIn, application, userId }: ProgramsP
   const [selectedActivity, setSelectedActivity] = useState<ActivityType | null>(null);
   const [isApplicationCompleted, setIsApplicationCompleted] = useState(false);
 
+  if (activities.length === 0) {
+    return (
+      <CompletionMessage
+        title="학과 체험 신청 기간이 아닙니다"
+        description="학과 체험 신청 기간은 9월 16일부터 22일까지 입니다."
+      />
+    );
+  }
+
   if (!isLoggedIn) {
     return (
       <CompletionMessage


### PR DESCRIPTION
## 개요 💡

`/programs` 접속 시 로그인 여부와 학과 체험 신청 여부만 확인하고 있어서, 학과 체험 신청 기간이 아닐 때(활동 목록이 비어 있을 때)는 별도 안내 없이 빈 화면이나 로그인 안내만 보이는 문제가 있었습니다.

## 작업내용 ⌨️

- `ProgramsPage.tsx`의 가드 분기 맨 앞에 `activities.length === 0` 체크를 추가
- 신청 기간이 아니면 로그인 여부와 무관하게 `CompletionMessage`로 "학과 체험 신청 기간이 아닙니다 / 학과 체험 신청 기간은 9월 16일부터 22일까지 입니다" 안내 표시

## 관련 이슈 🚨

Closes #65

## 리뷰 요청사항 👀

- 새 체크를 로그인/신청완료 체크보다 먼저 배치한 순서가 적절한지 확인해주세요.