### PR TITLE
[fix] 학과 체험 신청 시작 시간을 오전 8시로 변경

### DIFF
--- a/src/features/manageActivity/model/types.ts
+++ b/src/features/manageActivity/model/types.ts
@@ -54,7 +54,7 @@ export const toActivityFirstCreateReqDto = (values: ActivityFirstCreateFormType)
   const currentYear = new Date().getFullYear();
   return {
     ...toBaseFields(values),
-    registrationStartAt: `${currentYear}-${pad(values.registrationStartMonth)}-${pad(values.registrationStartDay)}T00:00:00`,
+    registrationStartAt: `${currentYear}-${pad(values.registrationStartMonth)}-${pad(values.registrationStartDay)}T08:00:00`,
     registrationEndAt: `${currentYear}-${pad(values.registrationEndMonth)}-${pad(values.registrationEndDay)}T23:59:59`,
   };
 };


### PR DESCRIPTION
## 개요 💡

메인페이지에 노출되는 학과 체험 신청 기간 시작 시각이 "오전 12시(자정)"로 표시되어 사용자에게 착각을 일으킬 수 있었습니다. 실제 업무 시간에 맞춰 오전 8시로 시작하도록 변경했습니다.

## 작업내용 ⌨️

- 신규 학과 체험 등록 시 `registrationStartAt`을 `T00:00:00` → `T08:00:00`으로 변경 (`src/features/manageActivity/model/types.ts`)
- 메인페이지(`HomeSection1`)의 신청 기간 안내 문구가 이 값을 그대로 포맷하므로, 신규 등록 건부터 "오전 8시"로 노출됨

## 관련 이슈 🚨

(없음)