### PR TITLE
[fix] 어드민 헤더 네비게이션 활성 링크 중복 표시 수정

### DIFF
--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -53,15 +53,11 @@ const Header = () => {
 
   const handleMenuClose = () => setMenuOpenPathname(null);
 
-  const getIsActive = (href: string) => {
-    const matchingLinks = links.filter(
-      (link) => pathname === link.href || pathname.startsWith(link.href + '/'),
-    );
-    const mostSpecific = matchingLinks.reduce((a, b) => (b.href.length > a.href.length ? b : a), {
-      href: '',
-    });
-    return mostSpecific.href === href;
-  };
+  const activeLink = links
+    .filter((link) => pathname === link.href || pathname.startsWith(link.href + '/'))
+    .reduce((a, b) => (b.href.length > a.href.length ? b : a), { href: '' });
+
+  const getIsActive = (href: string) => activeLink.href === href;
 
   return (
     <header className={cn('sticky top-0 z-50 w-full bg-white')}>

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -53,8 +53,15 @@ const Header = () => {
 
   const handleMenuClose = () => setMenuOpenPathname(null);
 
-  const getIsActive = (href: string) =>
-    href === '/' ? pathname === '/' : pathname.startsWith(href);
+  const getIsActive = (href: string) => {
+    const matchingLinks = links.filter(
+      (link) => pathname === link.href || pathname.startsWith(link.href + '/'),
+    );
+    const mostSpecific = matchingLinks.reduce((a, b) => (b.href.length > a.href.length ? b : a), {
+      href: '',
+    });
+    return mostSpecific.href === href;
+  };
 
   return (
     <header className={cn('sticky top-0 z-50 w-full bg-white')}>


### PR DESCRIPTION
## 개요 💡
어드민 헤더 네비게이션에서 학과 체험과 신청자 두 메뉴가 동시에 활성화되는 버그를 수정합니다. 
`/admin/applicants` 경로가 `/admin`의 prefix와도 일치해 두 항목 모두 active 상태가 되는 문제였습니다.

## 작업내용 ⌨️

**원인**
`getIsActive`가 `pathname.startsWith(href)`로 판단하기 때문에
`/admin/applicants`에서 `/admin`도 매칭되어 두 메뉴가 동시에 활성화됨

**수정**
현재 경로와 prefix 매칭되는 링크들을 모두 구한 뒤, 가장 긴(구체적인) 경로를 가진 링크만 active 처리하도록 변경

## 스크린샷/동영상 📸


https://github.com/user-attachments/assets/82c72c54-ba03-4467-ab99-f242ff43a5f5



## 관련 이슈 🚨

https://github.com/themoment-team/readygsm-client/issues/85

