### PR TITLE
[fix] 신청기간 종료 후 학과체험 취소 버튼 비활성화 처리

### DIFF
--- a/src/widgets/applicationSection/ui/ApplicationSection.tsx
+++ b/src/widgets/applicationSection/ui/ApplicationSection.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 
+import { toast } from 'react-toastify';
+
 import { type ActivityType } from '@/entities/activity';
 import { type ApplicationType } from '@/entities/application';
 import { ProgramCard } from '@/entities/program';
@@ -18,6 +20,16 @@ interface ApplicationSectionProps {
 
 const ApplicationSection = ({ user, application, activity }: ApplicationSectionProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const isPeriodEnded = activity ? new Date() > new Date(activity.registrationEndAt) : false;
+
+  const handleCancelClick = () => {
+    if (isPeriodEnded) {
+      toast.error('학과체험 신청 취소 기간이 아닙니다.');
+      return;
+    }
+    setIsModalOpen(true);
+  };
 
   if (!user || user.role === 'UNAUTHENTICATED') {
     return (
@@ -110,7 +122,12 @@ const ApplicationSection = ({ user, application, activity }: ApplicationSectionP
           </div>
         </section>
 
-        <Button variant="outlineDanger" size="full" onClick={() => setIsModalOpen(true)}>
+        <Button
+          variant="outlineDanger"
+          size="full"
+          onClick={handleCancelClick}
+          className={cn(isPeriodEnded && 'cursor-not-allowed opacity-50 hover:bg-transparent')}
+        >
           학과 체험 취소
         </Button>
       </div>

--- a/src/widgets/applicationSection/ui/ApplicationSection.tsx
+++ b/src/widgets/applicationSection/ui/ApplicationSection.tsx
@@ -21,7 +21,11 @@ interface ApplicationSectionProps {
 const ApplicationSection = ({ user, application, activity }: ApplicationSectionProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const isPeriodEnded = activity ? new Date() > new Date(activity.registrationEndAt) : false;
+  const [isPeriodEnded] = useState(() =>
+    typeof window !== 'undefined' && activity
+      ? new Date() > new Date(activity.registrationEndAt)
+      : false,
+  );
 
   const handleCancelClick = () => {
     if (isPeriodEnded) {


### PR DESCRIPTION
## 개요 💡

신청기간이 종료된 이후에는 학과체험 취소가 불가능하도록 UI를 제한합니다.

## 작업내용 ⌨️

**원인**
취소 버튼이 신청기간 종료 여부와 관계없이 항상 활성화되어 있어, 기간 외 취소 시도가 가능했음

**수정**
- `activity.registrationEndAt`과 현재 시간을 비교해 `isPeriodEnded` 여부 판단
- 기간 종료 시 취소 버튼에 `opacity-50 cursor-not-allowed` 스타일 적용하여 시각적으로 비활성화
- 버튼 클릭 시 모달 대신 "학과체험 신청 취소 기간이 아닙니다." 토스트 메시지 표시

## 관련 이슈 🚨
https://github.com/themoment-team/readygsm-client/issues/90