### PR TITLE
[feat] 학과체험 시간 입력을 드롭다운 선택으로 변경

### DIFF
--- a/src/features/manageActivity/model/types.ts
+++ b/src/features/manageActivity/model/types.ts
@@ -10,10 +10,10 @@ const baseActivityFields = {
   activityYear: z.string().min(1, '년도를 선택해주세요'),
   activityMonth: z.string().min(1, '월을 선택해주세요'),
   activityDay: z.string().min(1, '일을 선택해주세요'),
-  activityStartHour: z.string().min(1, '시를 입력해주세요'),
-  activityStartMinute: z.string().min(1, '분을 입력해주세요'),
-  activityEndHour: z.string().min(1, '시를 입력해주세요'),
-  activityEndMinute: z.string().min(1, '분을 입력해주세요'),
+  activityStartHour: z.string().min(1, '시를 선택해주세요'),
+  activityStartMinute: z.string().min(1, '분을 선택해주세요'),
+  activityEndHour: z.string().min(1, '시를 선택해주세요'),
+  activityEndMinute: z.string().min(1, '분을 선택해주세요'),
 };
 
 export const ActivityBaseFormSchema = z.object(baseActivityFields);
@@ -72,9 +72,9 @@ export const toFormValues = (activity: ActivityType): ActivityBaseFormType => {
     activityYear: actYear,
     activityMonth: String(parseInt(actMonth, 10)),
     activityDay: String(parseInt(actDay, 10)),
-    activityStartHour: startHour,
-    activityStartMinute: startMinute,
-    activityEndHour: endHour,
-    activityEndMinute: endMinute,
+    activityStartHour: String(parseInt(startHour, 10)),
+    activityStartMinute: String(parseInt(startMinute, 10)),
+    activityEndHour: String(parseInt(endHour, 10)),
+    activityEndMinute: String(parseInt(endMinute, 10)),
   };
 };

--- a/src/features/manageActivity/model/types.ts
+++ b/src/features/manageActivity/model/types.ts
@@ -72,9 +72,9 @@ export const toFormValues = (activity: ActivityType): ActivityBaseFormType => {
     activityYear: actYear,
     activityMonth: String(parseInt(actMonth, 10)),
     activityDay: String(parseInt(actDay, 10)),
-    activityStartHour: String(parseInt(startHour, 10)),
-    activityStartMinute: String(parseInt(startMinute, 10)),
-    activityEndHour: String(parseInt(endHour, 10)),
-    activityEndMinute: String(parseInt(endMinute, 10)),
+    activityStartHour: startHour ? String(parseInt(startHour, 10)) : '',
+    activityStartMinute: startMinute ? String(parseInt(startMinute, 10)) : '',
+    activityEndHour: endHour ? String(parseInt(endHour, 10)) : '',
+    activityEndMinute: endMinute ? String(parseInt(endMinute, 10)) : '',
   };
 };

--- a/src/features/manageActivity/ui/ActivityFormView.tsx
+++ b/src/features/manageActivity/ui/ActivityFormView.tsx
@@ -151,7 +151,7 @@ const ActivityFormView = ({
               render={({ field }) => (
                 <Select value={field.value ?? ''} onValueChange={field.onChange}>
                   <SelectTrigger
-                    className={cn('flex-1', formErrors.activityYear && 'border-error-red')}
+                    className={cn('w-full flex-1', formErrors.activityYear && 'border-error-red')}
                   >
                     <SelectValue placeholder="년도 입력" />
                   </SelectTrigger>
@@ -174,7 +174,7 @@ const ActivityFormView = ({
               render={({ field }) => (
                 <Select value={field.value ?? ''} onValueChange={field.onChange}>
                   <SelectTrigger
-                    className={cn('flex-1', formErrors.activityMonth && 'border-error-red')}
+                    className={cn('w-full flex-1', formErrors.activityMonth && 'border-error-red')}
                   >
                     <SelectValue placeholder="월 입력" />
                   </SelectTrigger>
@@ -197,7 +197,7 @@ const ActivityFormView = ({
               render={({ field }) => (
                 <Select value={field.value ?? ''} onValueChange={field.onChange}>
                   <SelectTrigger
-                    className={cn('flex-1', formErrors.activityDay && 'border-error-red')}
+                    className={cn('w-full flex-1', formErrors.activityDay && 'border-error-red')}
                   >
                     <SelectValue placeholder="일 입력" />
                   </SelectTrigger>
@@ -225,7 +225,10 @@ const ActivityFormView = ({
               render={({ field }) => (
                 <Select value={field.value ?? ''} onValueChange={field.onChange}>
                   <SelectTrigger
-                    className={cn('flex-1', formErrors.activityStartHour && 'border-error-red')}
+                    className={cn(
+                      'w-full flex-1',
+                      formErrors.activityStartHour && 'border-error-red',
+                    )}
                   >
                     <SelectValue placeholder="시 선택" />
                   </SelectTrigger>
@@ -248,7 +251,10 @@ const ActivityFormView = ({
               render={({ field }) => (
                 <Select value={field.value ?? ''} onValueChange={field.onChange}>
                   <SelectTrigger
-                    className={cn('flex-1', formErrors.activityStartMinute && 'border-error-red')}
+                    className={cn(
+                      'w-full flex-1',
+                      formErrors.activityStartMinute && 'border-error-red',
+                    )}
                   >
                     <SelectValue placeholder="분 선택" />
                   </SelectTrigger>
@@ -276,7 +282,10 @@ const ActivityFormView = ({
               render={({ field }) => (
                 <Select value={field.value ?? ''} onValueChange={field.onChange}>
                   <SelectTrigger
-                    className={cn('flex-1', formErrors.activityEndHour && 'border-error-red')}
+                    className={cn(
+                      'w-full flex-1',
+                      formErrors.activityEndHour && 'border-error-red',
+                    )}
                   >
                     <SelectValue placeholder="시 선택" />
                   </SelectTrigger>
@@ -299,7 +308,10 @@ const ActivityFormView = ({
               render={({ field }) => (
                 <Select value={field.value ?? ''} onValueChange={field.onChange}>
                   <SelectTrigger
-                    className={cn('flex-1', formErrors.activityEndMinute && 'border-error-red')}
+                    className={cn(
+                      'w-full flex-1',
+                      formErrors.activityEndMinute && 'border-error-red',
+                    )}
                   >
                     <SelectValue placeholder="분 선택" />
                   </SelectTrigger>

--- a/src/features/manageActivity/ui/ActivityFormView.tsx
+++ b/src/features/manageActivity/ui/ActivityFormView.tsx
@@ -44,6 +44,8 @@ const CURRENT_YEAR = new Date().getFullYear();
 const YEARS = Array.from({ length: 5 }, (_, i) => CURRENT_YEAR + i - 1);
 const MONTHS = Array.from({ length: 12 }, (_, i) => i + 1);
 const DAYS = Array.from({ length: 31 }, (_, i) => i + 1);
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+const MINUTES = Array.from({ length: 60 }, (_, i) => i);
 
 const ActivityFormView = ({
   mode,
@@ -210,46 +212,102 @@ const ActivityFormView = ({
 
         <FormField label="체험 시작 시간">
           <div className={cn('flex gap-2')}>
-            <Input
-              {...form.register('activityStartHour')}
-              placeholder="시를 입력해주세요"
-              type="number"
-              min={0}
-              max={23}
-              className={cn('flex-1')}
-              error={!!formErrors.activityStartHour}
+            <Controller
+              name="activityStartHour"
+              control={form.control}
+              render={({ field }) => (
+                <Select value={field.value ?? ''} onValueChange={field.onChange}>
+                  <SelectTrigger
+                    className={cn('flex-1', formErrors.activityStartHour && 'border-error-red')}
+                  >
+                    <SelectValue placeholder="시 선택" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>시 선택</SelectLabel>
+                      {HOURS.map((h) => (
+                        <SelectItem key={h} value={String(h)}>
+                          {h}시
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              )}
             />
-            <Input
-              {...form.register('activityStartMinute')}
-              placeholder="분을 입력해주세요"
-              type="number"
-              min={0}
-              max={59}
-              className={cn('flex-1')}
-              error={!!formErrors.activityStartMinute}
+            <Controller
+              name="activityStartMinute"
+              control={form.control}
+              render={({ field }) => (
+                <Select value={field.value ?? ''} onValueChange={field.onChange}>
+                  <SelectTrigger
+                    className={cn('flex-1', formErrors.activityStartMinute && 'border-error-red')}
+                  >
+                    <SelectValue placeholder="분 선택" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>분 선택</SelectLabel>
+                      {MINUTES.map((m) => (
+                        <SelectItem key={m} value={String(m)}>
+                          {m}분
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              )}
             />
           </div>
         </FormField>
 
         <FormField label="체험 종료 시간">
           <div className={cn('flex gap-2')}>
-            <Input
-              {...form.register('activityEndHour')}
-              placeholder="시를 입력해주세요"
-              type="number"
-              min={0}
-              max={23}
-              className={cn('flex-1')}
-              error={!!formErrors.activityEndHour}
+            <Controller
+              name="activityEndHour"
+              control={form.control}
+              render={({ field }) => (
+                <Select value={field.value ?? ''} onValueChange={field.onChange}>
+                  <SelectTrigger
+                    className={cn('flex-1', formErrors.activityEndHour && 'border-error-red')}
+                  >
+                    <SelectValue placeholder="시 선택" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>시 선택</SelectLabel>
+                      {HOURS.map((h) => (
+                        <SelectItem key={h} value={String(h)}>
+                          {h}시
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              )}
             />
-            <Input
-              {...form.register('activityEndMinute')}
-              placeholder="분을 입력해주세요"
-              type="number"
-              min={0}
-              max={59}
-              className={cn('flex-1')}
-              error={!!formErrors.activityEndMinute}
+            <Controller
+              name="activityEndMinute"
+              control={form.control}
+              render={({ field }) => (
+                <Select value={field.value ?? ''} onValueChange={field.onChange}>
+                  <SelectTrigger
+                    className={cn('flex-1', formErrors.activityEndMinute && 'border-error-red')}
+                  >
+                    <SelectValue placeholder="분 선택" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>분 선택</SelectLabel>
+                      {MINUTES.map((m) => (
+                        <SelectItem key={m} value={String(m)}>
+                          {m}분
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              )}
             />
           </div>
         </FormField>

--- a/src/features/manageActivity/ui/ActivityFormView.tsx
+++ b/src/features/manageActivity/ui/ActivityFormView.tsx
@@ -47,6 +47,13 @@ const DAYS = Array.from({ length: 31 }, (_, i) => i + 1);
 const HOURS = Array.from({ length: 24 }, (_, i) => i);
 const MINUTES = Array.from({ length: 6 }, (_, i) => i * 10);
 
+const getMinuteOptions = (value?: string) => {
+  const numVal = value !== undefined && value !== '' ? Number(value) : NaN;
+  return !isNaN(numVal) && !MINUTES.includes(numVal)
+    ? [...MINUTES, numVal].sort((a, b) => a - b)
+    : MINUTES;
+};
+
 const ActivityFormView = ({
   mode,
   activity,
@@ -248,7 +255,7 @@ const ActivityFormView = ({
                   <SelectContent>
                     <SelectGroup>
                       <SelectLabel>분 선택</SelectLabel>
-                      {MINUTES.map((m) => (
+                      {getMinuteOptions(field.value).map((m) => (
                         <SelectItem key={m} value={String(m)}>
                           {m}분
                         </SelectItem>
@@ -299,7 +306,7 @@ const ActivityFormView = ({
                   <SelectContent>
                     <SelectGroup>
                       <SelectLabel>분 선택</SelectLabel>
-                      {MINUTES.map((m) => (
+                      {getMinuteOptions(field.value).map((m) => (
                         <SelectItem key={m} value={String(m)}>
                           {m}분
                         </SelectItem>

--- a/src/features/manageActivity/ui/ActivityFormView.tsx
+++ b/src/features/manageActivity/ui/ActivityFormView.tsx
@@ -45,7 +45,7 @@ const YEARS = Array.from({ length: 5 }, (_, i) => CURRENT_YEAR + i - 1);
 const MONTHS = Array.from({ length: 12 }, (_, i) => i + 1);
 const DAYS = Array.from({ length: 31 }, (_, i) => i + 1);
 const HOURS = Array.from({ length: 24 }, (_, i) => i);
-const MINUTES = Array.from({ length: 60 }, (_, i) => i);
+const MINUTES = Array.from({ length: 6 }, (_, i) => i * 10);
 
 const ActivityFormView = ({
   mode,


### PR DESCRIPTION
## 개요 💡

어드민에서 학과체험 시간 입력 시 사용성을 높이기 위해 숫자 직접 입력 방식을 드롭다운 선택으로 변경합니다.

## 작업내용 ⌨️

**원인**
체험 시작/종료 시간의 시·분을 `type="number"` 입력으로 받고 있어 범위 외 값 입력이 가능하고 사용성이 낮았음

**수정**

- 체험 시작/종료 시(hour)를 Select 드롭다운(0~23시)으로 변경
- 체험 시작/종료 분(minute)을 10분 단위 Select 드롭다운(0, 10, 20, 30, 40, 50분)으로 변경
- 수정 폼에서 API 응답 시간값(`"08"`)을 드롭다운 옵션과 매칭되도록 정수 문자열로 변환
- 에러 메시지 "입력해주세요" → "선택해주세요"로 변경


## 관련 이슈 🚨
https://github.com/themoment-team/readygsm-client/issues/94