### PR TITLE
[feat] Google Search Console 사이트 소유권 인증 메타태그 추가

### DIFF
--- a/src/app/admin/form/page.tsx
+++ b/src/app/admin/form/page.tsx
@@ -1,6 +1,8 @@
 import getActivityList from '@/entities/activity/api/getActivityList';
 import { ActivityFormView } from '@/features/manageActivity';
 
+export const dynamic = 'force-dynamic';
+
 const AdminFormPage = async () => {
   const response = await getActivityList();
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,6 +44,9 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     images: ['/images/opengraph-image.png'],
   },
+  verification: {
+    google: 'vdWefvqjIbTnZs7zhDUSD1kwC',
+  },
 };
 
 const websiteJsonLd = {

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 
 import { getActivityList } from '@/entities/activity';
+
+export const dynamic = 'force-dynamic';
 import getMyApplication from '@/entities/application/api/getMyApplication';
 import getMyInfo from '@/entities/user/api/getMyInfo';
 import { ProgramsPage } from '@/views/programs';


### PR DESCRIPTION
## 개요 💡
Google Search Console에서 사이트 소유권을 인증하기 위해 메타태그를 추가합니다.
Search Console 등록을 통해 검색 노출 현황 모니터링 및 SEO 개선 작업을 진행할 수 있습니다.

## 작업내용 ⌨️

- `src/app/layout.tsx`의 metadata에 `verification.google` 필드 추가
- Next.js가 자동으로 `<meta name="google-site-verification" content="..." />`를 `<head>`에 렌더링