### PR TITLE
[refactor] 학과 체험 목록 비로그인 조회 허용

### DIFF
--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -17,12 +17,7 @@ const Programs = async () => {
   const application = isLoggedIn ? await getMyApplication(user.id) : undefined;
 
   return (
-    <ProgramsPage
-      activities={result?.data ?? []}
-      isLoggedIn={isLoggedIn}
-      application={!!application}
-      userId={user?.id}
-    />
+    <ProgramsPage activities={result?.data ?? []} application={!!application} userId={user?.id} />
   );
 };
 

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -12,9 +12,9 @@ export const metadata: Metadata = {
 
 const Programs = async () => {
   const [result, user] = await Promise.all([getActivityList(), getMyInfo()]);
-  const isLoggedIn = !!user && user.role !== 'UNAUTHENTICATED';
+  const canFetchApplication = !!user && user.role !== 'UNAUTHENTICATED';
 
-  const application = isLoggedIn ? await getMyApplication(user.id) : undefined;
+  const application = canFetchApplication ? await getMyApplication(user.id) : undefined;
 
   return (
     <ProgramsPage activities={result?.data ?? []} application={!!application} userId={user?.id} />

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -12,12 +12,16 @@ export const metadata: Metadata = {
 
 const Programs = async () => {
   const [result, user] = await Promise.all([getActivityList(), getMyInfo()]);
-  const canFetchApplication = !!user && user.role !== 'UNAUTHENTICATED';
+  const isLoggedIn = !!user && user.role !== 'UNAUTHENTICATED';
 
-  const application = canFetchApplication ? await getMyApplication(user.id) : undefined;
+  const application = isLoggedIn ? await getMyApplication(user.id) : undefined;
 
   return (
-    <ProgramsPage activities={result?.data ?? []} application={!!application} userId={user?.id} />
+    <ProgramsPage
+      activities={result?.data ?? []}
+      application={!!application}
+      userId={isLoggedIn ? user.id : undefined}
+    />
   );
 };
 

--- a/src/views/programs/ui/ProgramsPage.tsx
+++ b/src/views/programs/ui/ProgramsPage.tsx
@@ -10,12 +10,11 @@ import { HomeProgramSection } from '@/widgets/homeProgramSection';
 
 interface ProgramsPageProps {
   activities: ActivityType[];
-  isLoggedIn: boolean;
   application: boolean;
   userId?: number;
 }
 
-const ProgramsPage = ({ activities, isLoggedIn, application, userId }: ProgramsPageProps) => {
+const ProgramsPage = ({ activities, application, userId }: ProgramsPageProps) => {
   const [selectedActivity, setSelectedActivity] = useState<ActivityType | null>(null);
   const [isApplicationCompleted, setIsApplicationCompleted] = useState(false);
 
@@ -24,15 +23,6 @@ const ProgramsPage = ({ activities, isLoggedIn, application, userId }: ProgramsP
       <CompletionMessage
         title="학과 체험 신청 기간이 아닙니다"
         description="학과 체험 신청 기간은 9월 16일부터 22일까지 입니다."
-      />
-    );
-  }
-
-  if (!isLoggedIn) {
-    return (
-      <CompletionMessage
-        title="로그인이 필요한 기능입니다"
-        description="학과 체험 신청은 로그인이 필요한 기능입니다. 로그인 후 이용해주세요"
       />
     );
   }

--- a/src/views/programs/ui/ProgramsPage.tsx
+++ b/src/views/programs/ui/ProgramsPage.tsx
@@ -2,7 +2,10 @@
 
 import { useState } from 'react';
 
+import { toast } from 'react-toastify';
+
 import { ActivityType } from '@/entities/activity';
+import { LoginModal } from '@/features/auth';
 import { cn } from '@/shared/lib';
 import { CompletionMessage } from '@/shared/ui';
 import { ApplicationForm } from '@/widgets/applyDepartment';
@@ -17,6 +20,17 @@ interface ProgramsPageProps {
 const ProgramsPage = ({ activities, application, userId }: ProgramsPageProps) => {
   const [selectedActivity, setSelectedActivity] = useState<ActivityType | null>(null);
   const [isApplicationCompleted, setIsApplicationCompleted] = useState(false);
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+
+  const handleSelectActivity = (activity: ActivityType) => {
+    if (!userId) {
+      toast.error('로그인이 필요한 기능입니다.');
+      setIsLoginModalOpen(true);
+      return;
+    }
+
+    setSelectedActivity(activity);
+  };
 
   if (activities.length === 0) {
     return (
@@ -37,42 +51,45 @@ const ProgramsPage = ({ activities, application, userId }: ProgramsPageProps) =>
   }
 
   return (
-    <div
-      className={cn(
-        'mx-auto flex w-155.5 flex-col gap-9 py-9 xl:min-h-[calc(100vh-6.25rem)] xl:w-7xl xl:flex-row xl:justify-center',
-      )}
-    >
-      <div className={cn('flex flex-col gap-5')}>
-        <div>
-          <p className={cn('text-[1.5rem] font-bold', selectedActivity && 'opacity-[0.5]')}>
-            학과 체험 선택
-          </p>
-          <p className={cn('text-[0.875rem]')}>
-            신청 이후 선택한 체험을 변경할 수 없으니 신중히 선택해주세요.
-          </p>
-        </div>
-        <HomeProgramSection
-          activities={activities}
-          selectedActivityId={selectedActivity?.id}
-          onSelect={setSelectedActivity}
-        />
-      </div>
-      {selectedActivity && userId && (
+    <>
+      <div
+        className={cn(
+          'mx-auto flex w-155.5 flex-col gap-9 py-9 xl:min-h-[calc(100vh-6.25rem)] xl:w-7xl xl:flex-row xl:justify-center',
+        )}
+      >
         <div className={cn('flex flex-col gap-5')}>
           <div>
-            <p className={cn('text-[1.5rem] font-bold')}>체험 신청자 정보 작성</p>
+            <p className={cn('text-[1.5rem] font-bold', selectedActivity && 'opacity-[0.5]')}>
+              학과 체험 선택
+            </p>
             <p className={cn('text-[0.875rem]')}>
-              신청 이후 정보 수정이 불가하니 정보를 정확히 입력해 주세요.
+              신청 이후 선택한 체험을 변경할 수 없으니 신중히 선택해주세요.
             </p>
           </div>
-          <ApplicationForm
-            activityId={selectedActivity.id}
-            userId={userId}
-            onSuccess={() => setIsApplicationCompleted(true)}
+          <HomeProgramSection
+            activities={activities}
+            selectedActivityId={selectedActivity?.id}
+            onSelect={handleSelectActivity}
           />
         </div>
-      )}
-    </div>
+        {selectedActivity && userId && (
+          <div className={cn('flex flex-col gap-5')}>
+            <div>
+              <p className={cn('text-[1.5rem] font-bold')}>체험 신청자 정보 작성</p>
+              <p className={cn('text-[0.875rem]')}>
+                신청 이후 정보 수정이 불가하니 정보를 정확히 입력해 주세요.
+              </p>
+            </div>
+            <ApplicationForm
+              activityId={selectedActivity.id}
+              userId={userId}
+              onSuccess={() => setIsApplicationCompleted(true)}
+            />
+          </div>
+        )}
+      </div>
+      <LoginModal isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />
+    </>
   );
 };
 


### PR DESCRIPTION
## 개요 💡

기존에는 로그인해야만 `/programs`에서 학과 체험 목록을 볼 수 있는 구조였습니다. 이 때문에 비로그인 방문자에게 어떤 체험 프로그램이 열리는지 정보를 전혀 제공하지 못했습니다.

로그인 여부와 무관하게 학과 체험 목록을 조회할 수 있도록 로그인 확인 분기를 제거했습니다.

## 작업내용 ⌨️

- `ProgramsPage`에서 `!isLoggedIn`일 때 "로그인이 필요한 기능입니다" 안내 화면을 반환하던 early return 제거
- 더 이상 쓰이지 않는 `isLoggedIn` prop을 `ProgramsPageProps`와 `app/programs/page.tsx`의 전달부에서 제거
- `app/programs/page.tsx`에 남은 로그인 여부 변수는 신청 내역 조회 가드 용도로만 쓰이므로 `canFetchApplication`으로 이름 변경 (동작 변화 없음)

신청 폼은 기존과 동일하게 `selectedActivity && userId` 조건에서만 렌더링되므로, 비로그인 사용자는 목록 조회와 카드 선택까지만 가능합니다.

## 관련 이슈 🚨

close #99 #100 


## 리뷰 요청사항 👀

- 신청 기간 아님 / 신청 완료 안내 화면 분기는 그대로 유지했습니다. 비로그인 사용자에게도 "학과 체험 신청 기간이 아닙니다" 화면이 노출되는데, 이 동작이 의도에 맞는지 확인 부탁드립니다.
