### PR TITLE
[fix] Google Search Console 사이트 소유권 인증 메타태그 복구

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,6 +44,9 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     images: ['/images/opengraph-image.png'],
   },
+  verification: {
+    google: 'vdWefvqjIbTnZs7zhDUSD1kwC',
+  },
 };
 
 const websiteJsonLd = {

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 
 import { getActivityList } from '@/entities/activity';
+
+export const dynamic = 'force-dynamic';
 import getMyApplication from '@/entities/application/api/getMyApplication';
 import getMyInfo from '@/entities/user/api/getMyInfo';
 import { ProgramsPage } from '@/views/programs';

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -14,9 +14,9 @@ export const metadata: Metadata = {
 
 const Programs = async () => {
   const [result, user] = await Promise.all([getActivityList(), getMyInfo()]);
-  const isLoggedIn = !!user && user.role !== 'UNAUTHENTICATED';
+  const canFetchApplication = !!user && user.role !== 'UNAUTHENTICATED';
 
-  const application = isLoggedIn ? await getMyApplication(user.id) : undefined;
+  const application = canFetchApplication ? await getMyApplication(user.id) : undefined;
 
   return (
     <ProgramsPage activities={result?.data ?? []} application={!!application} userId={user?.id} />

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -14,12 +14,16 @@ export const metadata: Metadata = {
 
 const Programs = async () => {
   const [result, user] = await Promise.all([getActivityList(), getMyInfo()]);
-  const canFetchApplication = !!user && user.role !== 'UNAUTHENTICATED';
+  const isLoggedIn = !!user && user.role !== 'UNAUTHENTICATED';
 
-  const application = canFetchApplication ? await getMyApplication(user.id) : undefined;
+  const application = isLoggedIn ? await getMyApplication(user.id) : undefined;
 
   return (
-    <ProgramsPage activities={result?.data ?? []} application={!!application} userId={user?.id} />
+    <ProgramsPage
+      activities={result?.data ?? []}
+      application={!!application}
+      userId={isLoggedIn ? user.id : undefined}
+    />
   );
 };
 

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -19,12 +19,7 @@ const Programs = async () => {
   const application = isLoggedIn ? await getMyApplication(user.id) : undefined;
 
   return (
-    <ProgramsPage
-      activities={result?.data ?? []}
-      isLoggedIn={isLoggedIn}
-      application={!!application}
-      userId={user?.id}
-    />
+    <ProgramsPage activities={result?.data ?? []} application={!!application} userId={user?.id} />
   );
 };
 

--- a/src/views/programs/ui/ProgramsPage.tsx
+++ b/src/views/programs/ui/ProgramsPage.tsx
@@ -10,12 +10,11 @@ import { HomeProgramSection } from '@/widgets/homeProgramSection';
 
 interface ProgramsPageProps {
   activities: ActivityType[];
-  isLoggedIn: boolean;
   application: boolean;
   userId?: number;
 }
 
-const ProgramsPage = ({ activities, isLoggedIn, application, userId }: ProgramsPageProps) => {
+const ProgramsPage = ({ activities, application, userId }: ProgramsPageProps) => {
   const [selectedActivity, setSelectedActivity] = useState<ActivityType | null>(null);
   const [isApplicationCompleted, setIsApplicationCompleted] = useState(false);
 
@@ -24,15 +23,6 @@ const ProgramsPage = ({ activities, isLoggedIn, application, userId }: ProgramsP
       <CompletionMessage
         title="학과 체험 신청 기간이 아닙니다"
         description="학과 체험 신청 기간은 9월 16일부터 22일까지 입니다."
-      />
-    );
-  }
-
-  if (!isLoggedIn) {
-    return (
-      <CompletionMessage
-        title="로그인이 필요한 기능입니다"
-        description="학과 체험 신청은 로그인이 필요한 기능입니다. 로그인 후 이용해주세요"
       />
     );
   }

--- a/src/views/programs/ui/ProgramsPage.tsx
+++ b/src/views/programs/ui/ProgramsPage.tsx
@@ -2,7 +2,10 @@
 
 import { useState } from 'react';
 
+import { toast } from 'react-toastify';
+
 import { ActivityType } from '@/entities/activity';
+import { LoginModal } from '@/features/auth';
 import { cn } from '@/shared/lib';
 import { CompletionMessage } from '@/shared/ui';
 import { ApplicationForm } from '@/widgets/applyDepartment';
@@ -17,6 +20,17 @@ interface ProgramsPageProps {
 const ProgramsPage = ({ activities, application, userId }: ProgramsPageProps) => {
   const [selectedActivity, setSelectedActivity] = useState<ActivityType | null>(null);
   const [isApplicationCompleted, setIsApplicationCompleted] = useState(false);
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+
+  const handleSelectActivity = (activity: ActivityType) => {
+    if (!userId) {
+      toast.error('로그인이 필요한 기능입니다.');
+      setIsLoginModalOpen(true);
+      return;
+    }
+
+    setSelectedActivity(activity);
+  };
 
   if (activities.length === 0) {
     return (
@@ -37,42 +51,45 @@ const ProgramsPage = ({ activities, application, userId }: ProgramsPageProps) =>
   }
 
   return (
-    <div
-      className={cn(
-        'mx-auto flex w-155.5 flex-col gap-9 py-9 xl:min-h-[calc(100vh-6.25rem)] xl:w-7xl xl:flex-row xl:justify-center',
-      )}
-    >
-      <div className={cn('flex flex-col gap-5')}>
-        <div>
-          <p className={cn('text-[1.5rem] font-bold', selectedActivity && 'opacity-[0.5]')}>
-            학과 체험 선택
-          </p>
-          <p className={cn('text-[0.875rem]')}>
-            신청 이후 선택한 체험을 변경할 수 없으니 신중히 선택해주세요.
-          </p>
-        </div>
-        <HomeProgramSection
-          activities={activities}
-          selectedActivityId={selectedActivity?.id}
-          onSelect={setSelectedActivity}
-        />
-      </div>
-      {selectedActivity && userId && (
+    <>
+      <div
+        className={cn(
+          'mx-auto flex w-155.5 flex-col gap-9 py-9 xl:min-h-[calc(100vh-6.25rem)] xl:w-7xl xl:flex-row xl:justify-center',
+        )}
+      >
         <div className={cn('flex flex-col gap-5')}>
           <div>
-            <p className={cn('text-[1.5rem] font-bold')}>체험 신청자 정보 작성</p>
+            <p className={cn('text-[1.5rem] font-bold', selectedActivity && 'opacity-[0.5]')}>
+              학과 체험 선택
+            </p>
             <p className={cn('text-[0.875rem]')}>
-              신청 이후 정보 수정이 불가하니 정보를 정확히 입력해 주세요.
+              신청 이후 선택한 체험을 변경할 수 없으니 신중히 선택해주세요.
             </p>
           </div>
-          <ApplicationForm
-            activityId={selectedActivity.id}
-            userId={userId}
-            onSuccess={() => setIsApplicationCompleted(true)}
+          <HomeProgramSection
+            activities={activities}
+            selectedActivityId={selectedActivity?.id}
+            onSelect={handleSelectActivity}
           />
         </div>
-      )}
-    </div>
+        {selectedActivity && userId && (
+          <div className={cn('flex flex-col gap-5')}>
+            <div>
+              <p className={cn('text-[1.5rem] font-bold')}>체험 신청자 정보 작성</p>
+              <p className={cn('text-[0.875rem]')}>
+                신청 이후 정보 수정이 불가하니 정보를 정확히 입력해 주세요.
+              </p>
+            </div>
+            <ApplicationForm
+              activityId={selectedActivity.id}
+              userId={userId}
+              onSuccess={() => setIsApplicationCompleted(true)}
+            />
+          </div>
+        )}
+      </div>
+      <LoginModal isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />
+    </>
   );
 };
 


### PR DESCRIPTION
## 개요 💡
PR #97(Google Search Console 사이트 소유권 인증 메타태그 추가)이 develop 브랜치 히스토리 재작성(force-push 추정)으로 유실되어, 해당 커밋을 다시 복구합니다.

## 작업내용 ⌨️
- `f99b8487` (PR #97 머지 커밋) cherry-pick으로 복구
- `src/app/layout.tsx`의 metadata에 `verification.google` 필드 재적용
- `src/app/programs/page.tsx`의 `export const dynamic = 'force-dynamic'` 재적용


## 이슈 🚨
https://github.com/themoment-team/readygsm-client/issues/102