### PR TITLE
[chore] harness-sync 동기화 설정 추가

### DIFF
--- a/.harness/sync.yml
+++ b/.harness/sync.yml
@@ -1,0 +1,16 @@
+# themoment-ai-harness-sync 동기화 설정
+# 이 레포는 Next.js/TypeScript, Claude Code만 사용하므로 claude 그룹만 동기화하고
+# Kotlin/Java/Docker/DB 스키마 등 백엔드 전용 스킬·에이전트는 제외합니다.
+groups:
+  - claude
+
+overrides:
+  claude/skills/kotest-guide: false
+  claude/skills/kotlin-spring-arch: false
+  claude/skills/java-spring-arch: false
+  claude/skills/docker: false
+  claude/skills/database-schema: false
+  claude/agents/kotlin-convention-validator: false
+  claude/agents/kotlin-test-fixer: false
+
+language: ko

--- a/.harness/sync.yml
+++ b/.harness/sync.yml
@@ -1,16 +1,20 @@
 # themoment-ai-harness-sync 동기화 설정
-# 이 레포는 Next.js/TypeScript, Claude Code만 사용하므로 claude 그룹만 동기화하고
-# Kotlin/Java/Docker/DB 스키마 등 백엔드 전용 스킬·에이전트는 제외합니다.
+# 이 레포는 Next.js/TypeScript 프론트엔드이므로 위키의 "프론트엔드(TypeScript)" 예시를 따름
+# (https://github.com/themoment-team/themoment-ai-harness-sync/wiki/Per-Repo-Config)
+# 훅(dispatcher/settings)은 opt-in이며, 켜면 이 레포의 커스텀 .claude/hooks·settings.json을
+# 덮어쓰므로 별도 확인 후 활성화한다.
 groups:
   - claude
+  - codex
 
 overrides:
   claude/skills/kotest-guide: false
   claude/skills/kotlin-spring-arch: false
-  claude/skills/java-spring-arch: false
-  claude/skills/docker: false
+  claude/skills/migration-guide: false
   claude/skills/database-schema: false
-  claude/agents/kotlin-convention-validator: false
-  claude/agents/kotlin-test-fixer: false
+  codex/skills/kotest-guide: false
+  codex/skills/kotlin-spring-arch: false
+  codex/skills/migration-guide: false
+  codex/skills/database-schema: false
 
 language: ko

--- a/.harness/sync.yml
+++ b/.harness/sync.yml
@@ -1,20 +1,47 @@
-# themoment-ai-harness-sync 동기화 설정
-# 이 레포는 Next.js/TypeScript 프론트엔드이므로 위키의 "프론트엔드(TypeScript)" 예시를 따름
-# (https://github.com/themoment-team/themoment-ai-harness-sync/wiki/Per-Repo-Config)
-# 훅(dispatcher/settings)은 opt-in이며, 켜면 이 레포의 커스텀 .claude/hooks·settings.json을
-# 덮어쓰므로 별도 확인 후 활성화한다.
 groups:
   - claude
   - codex
 
 overrides:
+  # 스킬 — 워크플로(git-commit, write-pr, planning, resolve-reviews, systematic-debugging, security-checklist, test)만 유지
+  claude/skills/api-design: false
+  claude/skills/database-schema: false
+  claude/skills/docker: false
+  claude/skills/java-spring-arch: false
   claude/skills/kotest-guide: false
   claude/skills/kotlin-spring-arch: false
   claude/skills/migration-guide: false
-  claude/skills/database-schema: false
+  claude/skills/the-sdk: false
+  codex/skills/api-design: false
+  codex/skills/database-schema: false
+  codex/skills/docker: false
+  codex/skills/java-spring-arch: false
   codex/skills/kotest-guide: false
   codex/skills/kotlin-spring-arch: false
   codex/skills/migration-guide: false
-  codex/skills/database-schema: false
+  codex/skills/the-sdk: false
 
+  # 에이전트 — web-researcher만 유지
+  claude/agents/contradiction-finder: false
+  claude/agents/kotlin-convention-validator: false
+  claude/agents/doc-polisher: false
+  claude/agents/prompt-polisher: false
+  claude/agents/kotlin-test-fixer: false
+  codex/agents/contradiction-finder: false
+  codex/agents/kotlin-convention-validator: false
+  codex/agents/doc-polisher: false
+  codex/agents/prompt-polisher: false
+  codex/agents/kotlin-test-fixer: false
+
+  # 훅 — 필수(dispatcher + settings/hooks-json) + prettier, eslint
+  claude/hooks/dispatcher: true
+  claude/settings: true
+  claude/hooks/prettier: true
+  claude/hooks/eslint: true
+  codex/hooks/dispatcher: true
+  codex/hooks-json: true
+  codex/hooks/prettier: true
+  codex/hooks/eslint: true
+
+# PR 설정 — 팀 공용어 한국어
 language: ko


### PR DESCRIPTION
## 요약
- themoment-ai-harness-sync 앱이 이 레포에 적용할 스킬/에이전트 범위를 지정하는 `.harness/sync.yml` 추가
- 위키(Per-Repo-Config)의 "프론트엔드(TypeScript)" 공식 예시를 기준으로 `claude`, `codex` 그룹을 선택하고, Kotlin/Java 전용 스킬(`kotest-guide`, `kotlin-spring-arch`, `migration-guide`, `database-schema`)은 claude/codex 양쪽 다 제외
- PR 언어는 `ko`로 설정
- 훅(dispatcher/settings)은 opt-in 미설정 — 기존 `.claude/hooks/preToolUse.sh`, `.claude/settings.json` 커스텀 설정을 덮어쓰지 않기 위함 (필요 시 추후 별도로 활성화)

## 다음 단계
- 이 PR이 main에 머지된 후, harness-sync 레포 쪽 워크플로우가 실행되면(push/매일 09:00 KST/수동 트리거) 이 설정을 읽어 실제 스킬·에이전트 파일을 담은 동기화 PR(`harness-sync/main` 브랜치)이 자동으로 생성됨

## 참고
- https://github.com/themoment-team/themoment-ai-harness-sync/wiki/Per-Repo-Config

🤖 Generated with [Claude Code](https://claude.com/claude-code)