### PR TITLE
[feat] 노션 DB 연결 후 서버 다운되어 있어도 학과체험 등시 작업

### DIFF
--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 
-import { getActivityList } from '@/entities/activity';
+import { getActivityArchiveList, getActivityList } from '@/entities/activity';
 
 export const dynamic = 'force-dynamic';
 import getMyApplication from '@/entities/application/api/getMyApplication';
@@ -13,7 +13,11 @@ export const metadata: Metadata = {
 };
 
 const Programs = async () => {
-  const [result, user] = await Promise.all([getActivityList(), getMyInfo()]);
+  const [result, user, archivedActivities] = await Promise.all([
+    getActivityList(),
+    getMyInfo(),
+    getActivityArchiveList().catch(() => []),
+  ]);
   const isLoggedIn = !!user && user.role !== 'UNAUTHENTICATED';
 
   const application = isLoggedIn ? await getMyApplication(user.id) : undefined;
@@ -21,6 +25,7 @@ const Programs = async () => {
   return (
     <ProgramsPage
       activities={result?.data ?? []}
+      archivedActivities={archivedActivities}
       application={!!application}
       userId={isLoggedIn ? user.id : undefined}
     />

--- a/src/entities/activity/api/getActivityArchiveList.ts
+++ b/src/entities/activity/api/getActivityArchiveList.ts
@@ -1,0 +1,65 @@
+import type { ActivityType } from '../model/types';
+
+interface NotionRichText {
+  plain_text: string;
+}
+
+interface NotionDateProperty {
+  date: { start: string; end: string | null } | null;
+}
+
+interface NotionActivityArchiveProperties {
+  이름: { title: NotionRichText[] };
+  장소: { rich_text: NotionRichText[] };
+  설명: { rich_text: NotionRichText[] };
+  '최대 인원': { number: number | null };
+  '체험 일시': NotionDateProperty;
+  '체험 종료 시각': { rich_text: NotionRichText[] };
+  '신청 시작일': NotionDateProperty;
+  '신청 종료일': NotionDateProperty;
+}
+
+interface NotionActivityArchivePage {
+  properties: NotionActivityArchiveProperties;
+}
+
+const NOTION_API = 'https://api.notion.com/v1';
+
+export async function getActivityArchiveList(): Promise<ActivityType[]> {
+  const DATABASE_ID = process.env.NOTION_ACTIVITY_ARCHIVE_DATABASE_ID;
+  const SECRET_KEY = process.env.NOTION_SECRET_API_KEY;
+
+  if (!DATABASE_ID || !SECRET_KEY) return [];
+
+  const res = await fetch(`${NOTION_API}/databases/${DATABASE_ID}/query`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${SECRET_KEY}`,
+      'Notion-Version': '2022-06-28',
+      'Content-Type': 'application/json',
+    },
+    next: { revalidate: process.env.NODE_ENV === 'production' ? 3600 : 0 },
+  });
+
+  if (!res.ok) throw new Error(`Notion API error: ${res.status}`);
+
+  const data = await res.json();
+
+  return data.results.map((page: NotionActivityArchivePage, index: number) => {
+    const properties = page.properties;
+
+    return {
+      id: index,
+      name: properties['이름'].title[0]?.plain_text ?? '',
+      place: properties['장소'].rich_text[0]?.plain_text ?? '',
+      description: properties['설명'].rich_text[0]?.plain_text ?? '',
+      maxApplicant: properties['최대 인원'].number ?? 0,
+      currentApplicant: 0,
+      activityDate: properties['체험 일시'].date?.start.slice(0, 10) ?? '',
+      activityStartTime: properties['체험 일시'].date?.start.slice(11, 16) ?? '',
+      activityEndTime: properties['체험 종료 시각'].rich_text[0]?.plain_text ?? '',
+      registrationStartAt: properties['신청 시작일'].date?.start ?? '',
+      registrationEndAt: properties['신청 종료일'].date?.start ?? '',
+    };
+  });
+}

--- a/src/entities/activity/index.ts
+++ b/src/entities/activity/index.ts
@@ -1,3 +1,4 @@
+export { getActivityArchiveList } from './api/getActivityArchiveList';
 export { default as getActivityById } from './api/getActivityById';
 export { default as getActivityList } from './api/getActivityList';
 export { revalidateActivityList } from './api/revalidateActivityList';

--- a/src/views/programs/ui/ProgramsPage.tsx
+++ b/src/views/programs/ui/ProgramsPage.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { toast } from 'react-toastify';
 
 import { ActivityType } from '@/entities/activity';
+import { ProgramCard } from '@/entities/program';
 import { LoginModal } from '@/features/auth';
 import { cn } from '@/shared/lib';
 import { CompletionMessage } from '@/shared/ui';
@@ -13,11 +14,17 @@ import { HomeProgramSection } from '@/widgets/homeProgramSection';
 
 interface ProgramsPageProps {
   activities: ActivityType[];
+  archivedActivities: ActivityType[];
   application: boolean;
   userId?: number;
 }
 
-const ProgramsPage = ({ activities, application, userId }: ProgramsPageProps) => {
+const ProgramsPage = ({
+  activities,
+  archivedActivities,
+  application,
+  userId,
+}: ProgramsPageProps) => {
   const [selectedActivity, setSelectedActivity] = useState<ActivityType | null>(null);
   const [isApplicationCompleted, setIsApplicationCompleted] = useState(false);
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
@@ -33,6 +40,30 @@ const ProgramsPage = ({ activities, application, userId }: ProgramsPageProps) =>
   };
 
   if (activities.length === 0) {
+    if (archivedActivities.length > 0) {
+      return (
+        <div className={cn('mx-auto flex w-155.5 flex-col gap-9 py-9')}>
+          <div>
+            <p className={cn('text-[1.5rem] font-bold')}>학과 체험 신청 기간이 아닙니다</p>
+            <p className={cn('text-[0.875rem]')}>지난 학과 체험 프로그램을 소개해드립니다.</p>
+          </div>
+          <div className={cn('flex flex-col items-center gap-4')}>
+            {archivedActivities.map((activity) => (
+              <ProgramCard
+                key={activity.id}
+                name={activity.name}
+                description={activity.description}
+                activityDate={activity.activityDate}
+                maxApplicant={activity.maxApplicant}
+                currentApplicant={activity.currentApplicant}
+                disableHover
+              />
+            ))}
+          </div>
+        </div>
+      );
+    }
+
     return (
       <CompletionMessage
         title="학과 체험 신청 기간이 아닙니다"


### PR DESCRIPTION
## 개요 💡

학과체험 신청 기간이 종료되면 목록이 아예 안 보이던 기존 동작을 바꿔서, 학교 홍보 목적으로 지난 학과체험 정보를 계속 노출하도록 했습니다. 지난 데이터는 백엔드가 보존하지 않아, 운영진이 수동 관리하는 Notion DB를 데이터 소스로 사용합니다.

## 작업내용 ⌨️

- `entities/activity/api/getActivityArchiveList.ts`: Notion API에서 지난 학과체험 데이터를 조회해 기존 `ActivityType`으로 매핑하는 함수 추가 (기존 `entities/teamMember`의 Notion 연동 패턴을 그대로 재사용, `NOTION_SECRET_API_KEY`도 재사용)
- `entities/activity/index.ts`: 위 함수 barrel export 추가
- `app/programs/page.tsx`: 아카이브 데이터를 기존 `Promise.all`에 병렬로 추가해 `ProgramsPage`에 전달
- `views/programs/ui/ProgramsPage.tsx`: 신청 기간이 아니고(`activities.length === 0`) 아카이브 데이터가 있으면, 새 컴포넌트 없이 기존 `ProgramCard`(`entities/program`)를 `disableHover`로 재사용해 읽기 전용으로 노출(클릭 시 신청 동작 없음). 아카이브 데이터가 없으면(Database ID 미설정 포함) 기존 안내 문구(`CompletionMessage`) 그대로 유지되어 회귀 없음
- 신규 env: `NOTION_ACTIVITY_ARCHIVE_DATABASE_ID` (`.env.local`에 빈 값으로 추가, 값은 Notion DB 준비되는 대로 채울 예정)

## 관련 이슈 🚨

https://github.com/themoment-team/readygsm-client/issues/104

## 리뷰 요청사항 👀

- Notion 응답 파싱 시 property 키를 한글 컬럼명 그대로 사용합니다(`이름`, `장소`, `최대 인원` 등). Notion 쪽 컬럼명과 정확히 일치하는지 확인 부탁드립니다.
- 아카이브 카드의 `id`는 Notion에 숫자 ID가 없어 배열 인덱스로 채웠습니다(읽기 전용 카드라 신청 로직과 연결되지 않아 문제없다고 판단했는데, 의견 있으면 부탁드립니다).