### PR TITLE
[ci] 정기 배포 PR 자동 생성 워크플로우 추가

### DIFF
--- a/.github/workflows/regular-deploy.yml
+++ b/.github/workflows/regular-deploy.yml
@@ -1,0 +1,95 @@
+name: regular deploy PR creation
+
+on:
+  schedule:
+    - cron: '0 0 1,15 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  repository-projects: write
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch all branches
+        run: |
+          git fetch origin main
+          git fetch origin develop
+
+      - name: Check for changes between develop and main
+        id: check_changes
+        run: |
+          if git diff --quiet origin/main..origin/develop; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No changes between develop and main"
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Changes detected between develop and main"
+          fi
+
+      - name: Check if PR already exists
+        if: steps.check_changes.outputs.has_changes == 'true'
+        id: check_pr
+        run: |
+          PR_COUNT=$(gh pr list --base main --head develop --state open --json number | jq length)
+          if [ "$PR_COUNT" -gt 0 ]; then
+            echo "pr_exists=true" >> $GITHUB_OUTPUT
+            echo "Existing PR found"
+          else
+            echo "pr_exists=false" >> $GITHUB_OUTPUT
+            echo "No existing PR found"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Pull Request using GitHub CLI
+        if: steps.check_changes.outputs.has_changes == 'true' && steps.check_pr.outputs.pr_exists == 'false'
+        id: create_pr
+        run: |
+          PR_BODY=$(cat <<EOF
+          ### 개요 💡
+          develop 브랜치의 내용을 main 브랜치에 반영합니다.
+          EOF
+          )
+
+          PR_URL=$(gh pr create \
+            --title "[merge] 정기 배포" \
+            --body "$PR_BODY" \
+            --base main \
+            --head develop)
+
+          echo "pull-request-url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "PR created: $PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Success Discord Notification
+        uses: sarisia/actions-status-discord@v1.15.5
+        if: success()
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          title: '✅ 정기 배포 PR 생성 성공'
+          status: success
+          content: '정기 배포 PR이 성공적으로 생성되었습니다.'
+          username: readygsm-client bot
+          color: 0x4CAF50
+
+      - name: Failure Discord Notification
+        uses: sarisia/actions-status-discord@v1.15.5
+        if: failure()
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          title: '❌ 정기 배포 PR 생성 실패'
+          status: failure
+          content: '에러를 확인해주세요.'
+          username: readygsm-client bot
+          color: 0xe74c3c

--- a/.github/workflows/regular-deploy.yml
+++ b/.github/workflows/regular-deploy.yml
@@ -8,14 +8,13 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  repository-projects: write
 
 jobs:
   create-pr:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -28,7 +27,7 @@ jobs:
       - name: Check for changes between develop and main
         id: check_changes
         run: |
-          if git diff --quiet origin/main..origin/develop; then
+          if [ "$(git rev-list --count origin/main..origin/develop)" -eq 0 ]; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
             echo "No changes between develop and main"
           else
@@ -55,9 +54,16 @@ jobs:
         if: steps.check_changes.outputs.has_changes == 'true' && steps.check_pr.outputs.pr_exists == 'false'
         id: create_pr
         run: |
+          COMMITS=$(git log origin/main..origin/develop --oneline --no-merges)
+
           PR_BODY=$(cat <<EOF
           ### 개요 💡
           develop 브랜치의 내용을 main 브랜치에 반영합니다.
+
+          ### 변경 사항 📋
+          \`\`\`
+          $COMMITS
+          \`\`\`
           EOF
           )
 
@@ -74,12 +80,12 @@ jobs:
 
       - name: Success Discord Notification
         uses: sarisia/actions-status-discord@v1.15.5
-        if: success()
+        if: steps.create_pr.outcome == 'success'
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
           title: '✅ 정기 배포 PR 생성 성공'
           status: success
-          content: '정기 배포 PR이 성공적으로 생성되었습니다.'
+          content: ${{ steps.create_pr.outputs.pull-request-url }}
           username: readygsm-client bot
           color: 0x4CAF50
 


### PR DESCRIPTION
## 개요 💡

매월 정기 배포 시 `develop` → `main` PR을 수동으로 생성하던 작업을 자동화합니다.
배포 주기를 놓치거나 PR 생성을 깜빡하는 일을 방지하기 위해 스케줄 기반 워크플로우를 추가했습니다.

## 작업내용 ⌨️

- `.github/workflows/regular-deploy.yml` 추가
- 매월 1일, 15일 09:00 (KST) 자동 실행 + `workflow_dispatch`로 수동 실행 지원
- `develop`과 `main` 사이 변경사항이 있을 때만 PR 생성
- 이미 열린 `develop` → `main` PR이 있으면 중복 생성하지 않음
- PR 생성 성공/실패를 Discord로 알림

## 리뷰 요청사항 👀

- **CI 재검증은 의도적으로 넣지 않았습니다.** `GITHUB_TOKEN`으로 생성한 PR은 `ci.yml`을 트리거하지 않지만, `develop`으로 들어오는 모든 PR에서 이미 lint/build가 검증되고 Vercel preview 빌드도 별도로 동작하므로 정기 배포 PR 시점의 재검증은 중복이라고 판단했습니다. 이견 있으시면 말씀해주세요.
- **cron 주기**: 1일/15일 09:00 (KST) 주기가 팀 배포 일정과 맞는지 확인 부탁드립니다.
- `DISCORD_WEBHOOK_URL` 시크릿은 기존 `ci.yml`에서 쓰던 것을 그대로 사용합니다.
