### PR TITLE
[design] 학과 체험 신청 페이지 412 모바일 반응형 대응

### DIFF
--- a/src/entities/program/ui/ProgramCard.tsx
+++ b/src/entities/program/ui/ProgramCard.tsx
@@ -35,7 +35,7 @@ const ProgramCard = ({
   return (
     <section
       className={cn(
-        'w-155.5 max-w-155.5 rounded-lg border bg-white px-6 py-5',
+        'w-full max-w-155.5 rounded-lg border bg-white px-6 py-5',
         !disableHover &&
           !isApplyDisabled &&
           'cursor-pointer transition-colors duration-200 hover:bg-[#EFF4FF]',

--- a/src/shared/ui/CompletionMessage.tsx
+++ b/src/shared/ui/CompletionMessage.tsx
@@ -9,11 +9,15 @@ const CompletionMessage = ({ title, description }: CompletionMessageProps) => {
   return (
     <div
       className={cn(
-        'flex size-full min-h-[calc(100vh-6.25rem-11.3125rem)] flex-col items-center justify-center gap-4 text-center',
+        'flex size-full min-h-[calc(100vh-6.25rem-11.3125rem)] flex-col items-center justify-center gap-4 px-6 text-center',
       )}
     >
-      <p className={cn('text-brand-primary text-[3rem] leading-[1.2] font-bold')}>{title}</p>
-      <p className={cn('text-secondary-slate text-2xl leading-[1.2] font-normal')}>{description}</p>
+      <p className={cn('text-brand-primary text-2xl leading-[1.2] font-bold lg:text-[3rem]')}>
+        {title}
+      </p>
+      <p className={cn('text-secondary-slate text-sm leading-[1.4] font-normal lg:text-2xl')}>
+        {description}
+      </p>
     </div>
   );
 };

--- a/src/views/programs/ui/ProgramsPage.tsx
+++ b/src/views/programs/ui/ProgramsPage.tsx
@@ -42,10 +42,19 @@ const ProgramsPage = ({
   if (activities.length === 0) {
     if (archivedActivities.length > 0) {
       return (
-        <div className={cn('mx-auto flex w-155.5 flex-col gap-9 py-9')}>
-          <div>
-            <p className={cn('text-[1.5rem] font-bold')}>학과 체험 신청 기간이 아닙니다</p>
-            <p className={cn('text-[0.875rem]')}>지난 학과 체험 프로그램을 소개해드립니다.</p>
+        <div
+          className={cn(
+            'mx-auto flex w-full max-w-155.5 flex-col gap-12 px-6 py-6',
+            'lg:gap-9 lg:px-0 lg:py-9',
+          )}
+        >
+          <div className={cn('flex flex-col gap-2')}>
+            <p className={cn('text-neutral-dark text-[1.5rem] leading-[1.2] font-semibold')}>
+              학과 체험 신청 기간이 아닙니다
+            </p>
+            <p className={cn('text-secondary-slate text-[0.875rem] leading-[1.2]')}>
+              지난 학과 체험 프로그램을 소개해드립니다.
+            </p>
           </div>
           <div className={cn('flex flex-col items-center gap-4')}>
             {archivedActivities.map((activity) => (
@@ -85,15 +94,17 @@ const ProgramsPage = ({
     <>
       <div
         className={cn(
-          'mx-auto flex w-155.5 flex-col gap-9 py-9 xl:min-h-[calc(100vh-6.25rem)] xl:w-7xl xl:flex-row xl:justify-center',
+          'mx-auto flex w-full max-w-155.5 flex-col gap-12 px-6 py-6',
+          'lg:px-0 lg:py-9',
+          'xl:min-h-[calc(100vh-6.25rem)] xl:w-7xl xl:max-w-none xl:flex-row xl:justify-center xl:gap-9',
         )}
       >
-        <div className={cn('flex flex-col gap-5')}>
-          <div>
-            <p className={cn('text-[1.5rem] font-bold', selectedActivity && 'opacity-[0.5]')}>
+        <div className={cn('flex w-full flex-col gap-5 xl:w-155.5')}>
+          <div className={cn('flex flex-col gap-2', selectedActivity && 'opacity-[0.5]')}>
+            <p className={cn('text-neutral-dark text-[1.5rem] leading-[1.2] font-semibold')}>
               학과 체험 선택
             </p>
-            <p className={cn('text-[0.875rem]')}>
+            <p className={cn('text-secondary-slate text-[0.875rem] leading-[1.2]')}>
               신청 이후 선택한 체험을 변경할 수 없으니 신중히 선택해주세요.
             </p>
           </div>
@@ -104,10 +115,12 @@ const ProgramsPage = ({
           />
         </div>
         {selectedActivity && userId && (
-          <div className={cn('flex flex-col gap-5')}>
-            <div>
-              <p className={cn('text-[1.5rem] font-bold')}>체험 신청자 정보 작성</p>
-              <p className={cn('text-[0.875rem]')}>
+          <div className={cn('flex w-full flex-col gap-5 xl:w-155.5')}>
+            <div className={cn('flex flex-col gap-2')}>
+              <p className={cn('text-neutral-dark text-[1.5rem] leading-[1.2] font-semibold')}>
+                체험 신청자 정보 작성
+              </p>
+              <p className={cn('text-secondary-slate text-[0.875rem] leading-[1.2]')}>
                 신청 이후 정보 수정이 불가하니 정보를 정확히 입력해 주세요.
               </p>
             </div>

--- a/src/widgets/applyDepartment/ui/ApplicationForm.tsx
+++ b/src/widgets/applyDepartment/ui/ApplicationForm.tsx
@@ -70,7 +70,7 @@ const ApplicationForm = ({ activityId, userId, onSuccess }: ApplicationFormProps
   };
 
   return (
-    <form onSubmit={handleSubmit} className={cn('flex w-155.5 flex-col')}>
+    <form onSubmit={handleSubmit} className={cn('flex w-full flex-col')}>
       <SearchSchoolModal
         isOpen={isSchoolModalOpen}
         onClose={() => setIsSchoolModalOpen(false)}
@@ -104,11 +104,11 @@ const ApplicationForm = ({ activityId, userId, onSuccess }: ApplicationFormProps
               <Select value={field.value ?? ''} onValueChange={field.onChange}>
                 <SelectTrigger
                   className={cn(
-                    'w-auto flex-1',
+                    'w-auto min-w-0 flex-1 overflow-hidden',
                     errors.grade && 'border-error-red hover:border-error-red',
                   )}
                 >
-                  <SelectValue placeholder="학년을 선택해주세요" />
+                  <SelectValue placeholder="학년 선택" />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="1">1학년</SelectItem>
@@ -125,11 +125,11 @@ const ApplicationForm = ({ activityId, userId, onSuccess }: ApplicationFormProps
               <Select value={field.value ?? ''} onValueChange={field.onChange}>
                 <SelectTrigger
                   className={cn(
-                    'w-auto flex-1',
+                    'w-auto min-w-0 flex-1 overflow-hidden',
                     errors.classNum && 'border-error-red hover:border-error-red',
                   )}
                 >
-                  <SelectValue placeholder="반을 선택해주세요" />
+                  <SelectValue placeholder="반 선택" />
                 </SelectTrigger>
                 <SelectContent>
                   {Array.from({ length: 20 }, (_, i) => (
@@ -142,10 +142,10 @@ const ApplicationForm = ({ activityId, userId, onSuccess }: ApplicationFormProps
             )}
           />
           <Input
-            placeholder="번호를 입력해주세요"
+            placeholder="번호 입력"
             error={!!errors.number}
             {...register('number')}
-            className={cn('flex-1')}
+            className={cn('min-w-0 flex-1')}
           />
         </div>
         <p className={cn('text-error-red min-h-4 text-xs leading-4 font-normal')}>

--- a/src/widgets/homeProgramSection/ui/HomeProgramSection/index.tsx
+++ b/src/widgets/homeProgramSection/ui/HomeProgramSection/index.tsx
@@ -16,7 +16,7 @@ const HomeProgramSection = ({
   onSelect,
 }: HomeProgramSectionProps) => {
   return (
-    <main className={cn('flex flex-col items-center justify-center gap-4 bg-white')}>
+    <main className={cn('flex w-full flex-col items-center justify-center gap-4 bg-white')}>
       {activities.map((activity) => (
         <ProgramCard
           key={activity.id}


### PR DESCRIPTION
## 개요

학과 체험 신청 페이지(`/programs`)를 412 모바일 뷰포트에 대응시켰습니다.
헤더·푸터는 이번 작업 범위에서 제외했습니다.

디자인 참고
- [학과 체험 선택 (미선택 상태)](https://www.figma.com/design/O2bHfV819OartFfRsq4IrN/Ready-GSM?node-id=3713-18398&m=dev)
- [학과 체험 선택 + 신청자 정보 작성 (선택 상태)](https://www.figma.com/design/O2bHfV819OartFfRsq4IrN/Ready-GSM?node-id=3713-18427&m=dev)

## 작업 내용

### 학과 체험 카드 고정 폭 제거
- `ProgramCard`의 `w-155.5`(622px) 고정 폭을 `w-full max-w-155.5`로 변경
- `HomeProgramSection`에 `w-full` 추가

### 페이지 컨테이너 반응형
- 모바일 기준 좌우 24px 여백(`px-6`), 상하 24px(`py-6`) 적용, `lg` 이상에서 기존 값 유지
- 학과 체험 선택 ↔ 신청자 정보 작성 섹션 간격을 피그마 값인 48px(`gap-12`)로 적용, `xl`에서는 기존 가로 배치 유지
- 두 컬럼에 `w-full xl:w-155.5`를 부여해 데스크톱 레이아웃을 그대로 보존
- 섹션 헤더 색상(`text-neutral-dark` / `text-secondary-slate`)과 8px 간격을 피그마에 맞춤
- 체험 선택 시 흐려지는 처리를 제목만이 아니라 헤더 블록 전체에 적용 (피그마 기준)

### 신청자 정보 폼 반응형
- `ApplicationForm`의 `w-155.5` 고정 폭을 `w-full`로 변경
- 학년/반/번호가 412에서 한 줄에 들어가도록 `min-w-0` 추가
- placeholder를 피그마의 축약 문구로 변경 (`학년을 선택해주세요` → `학년 선택`, `반을 선택해주세요` → `반 선택`, `번호를 입력해주세요` → `번호 입력`)

### 신청 완료·기간 종료 메시지 반응형
- 피그마에 포함된 화면은 아니지만, 같은 페이지의 상태 화면에서 48px 제목이 412에서 넘쳐 타이포 스케일을 모바일 기준으로 낮추고 `lg` 이상에서 기존 크기를 유지하도록 했습니다.

## 스크린샷/동영상 📸
<img width="608" height="1236" alt="image" src="https://github.com/user-attachments/assets/5e21dfa7-0ae2-4900-bec8-631a73224f73" />

## 확인

- `pnpm lint` 통과
- `tsc --noEmit` 통과
- `pnpm build` 통과

## 참고

- 로컬 `design/responsive` 브랜치가 `origin/develop`과 동일해서 PR base를 `develop`으로 잡았습니다. 다른 브랜치를 원하시면 변경하겠습니다.
- 카드 선택 상태 테두리 색은 피그마 내에서도 값이 엇갈려(`#2563EB` / `#4A80F8`) 반응형 범위 밖으로 보고 기존 값을 유지했습니다. 통일이 필요하면 알려주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)