### PR TITLE
[design] 신청 조회 페이지 412 모바일 반응형 대응

### DIFF
--- a/src/entities/program/ui/ProgramCard.tsx
+++ b/src/entities/program/ui/ProgramCard.tsx
@@ -35,7 +35,7 @@ const ProgramCard = ({
   return (
     <section
       className={cn(
-        'w-155.5 max-w-155.5 rounded-lg border bg-white px-6 py-5',
+        'w-full max-w-155.5 rounded-lg border bg-white px-6 py-5',
         !disableHover &&
           !isApplyDisabled &&
           'cursor-pointer transition-colors duration-200 hover:bg-[#EFF4FF]',

--- a/src/shared/ui/EmptyState.tsx
+++ b/src/shared/ui/EmptyState.tsx
@@ -11,11 +11,19 @@ interface EmptyStateProps {
 const EmptyState = ({ title, description, children }: EmptyStateProps) => (
   <main
     className={cn(
-      'flex min-h-[calc(100vh-6.25rem-11.3125rem)] flex-col items-center justify-center gap-2 bg-white',
+      'flex flex-col items-center justify-center bg-white px-6 text-center',
+      'min-h-111.25 gap-4',
+      'lg:min-h-[calc(100vh-6.25rem-11.3125rem)] lg:gap-2',
     )}
   >
-    <h1 className={cn('text-brand-primary text-[3rem] font-bold')}>{title}</h1>
-    {description && <p className={cn('text-secondary-slate text-[1.5rem]')}>{description}</p>}
+    <h1 className={cn('text-brand-primary text-2xl leading-[1.2] font-bold lg:text-[3rem]')}>
+      {title}
+    </h1>
+    {description && (
+      <p className={cn('text-secondary-slate text-sm leading-[1.2] lg:text-[1.5rem]')}>
+        {description}
+      </p>
+    )}
     {children}
   </main>
 );

--- a/src/widgets/applicationSection/ui/ApplicationSection.tsx
+++ b/src/widgets/applicationSection/ui/ApplicationSection.tsx
@@ -81,29 +81,29 @@ const ApplicationSection = ({ user, application, activity }: ApplicationSectionP
           </section>
         )}
 
-        <section className={cn('flex flex-col gap-4')}>
+        <section className={cn('flex flex-col gap-5 lg:gap-4')}>
           <SectionHeader
             title="신청자 정보"
             description="학과 체험을 신청한 사람의 정보를 불러옵니다."
           />
           <div className={cn('border-border-variant w-full rounded-lg border bg-white px-6 py-5')}>
-            <div className={cn('grid grid-cols-2 gap-4')}>
+            <div className={cn('grid grid-cols-1 gap-4 lg:grid-cols-2')}>
               <dl className={cn('flex flex-col gap-4')}>
                 <div className={cn('flex gap-4')}>
-                  <dt className={cn('text-secondary-slate w-14 shrink-0 text-sm')}>이름</dt>
+                  <dt className={cn('text-secondary-slate w-14 shrink-0 text-xs lg:text-sm')}>이름</dt>
                   <dd className={cn('text-neutral-dark text-sm font-medium')}>
                     {application.name}
                   </dd>
                 </div>
                 <div className={cn('flex gap-4')}>
-                  <dt className={cn('text-secondary-slate w-14 shrink-0 text-sm')}>학번</dt>
+                  <dt className={cn('text-secondary-slate w-14 shrink-0 text-xs lg:text-sm')}>학번</dt>
                   <dd className={cn('text-neutral-dark text-sm font-medium')}>
                     {application.grade}학년 {application.classNumber}반{' '}
                     {String(application.number).padStart(2, '0')}번
                   </dd>
                 </div>
                 <div className={cn('flex gap-4')}>
-                  <dt className={cn('text-secondary-slate w-14 shrink-0 text-sm')}>학교명</dt>
+                  <dt className={cn('text-secondary-slate w-14 shrink-0 text-xs lg:text-sm')}>학교명</dt>
                   <dd className={cn('text-neutral-dark text-sm font-medium')}>
                     {application.schoolName}
                   </dd>
@@ -111,13 +111,13 @@ const ApplicationSection = ({ user, application, activity }: ApplicationSectionP
               </dl>
               <dl className={cn('flex flex-col gap-4')}>
                 <div className={cn('flex gap-4')}>
-                  <dt className={cn('text-secondary-slate w-24 shrink-0 text-sm')}>전화번호</dt>
+                  <dt className={cn('text-secondary-slate w-24 shrink-0 text-xs whitespace-nowrap lg:text-sm')}>전화번호</dt>
                   <dd className={cn('text-neutral-dark text-sm font-medium')}>
                     {application.phoneNumber}
                   </dd>
                 </div>
                 <div className={cn('flex gap-4')}>
-                  <dt className={cn('text-secondary-slate w-24 shrink-0 text-sm')}>
+                  <dt className={cn('text-secondary-slate w-24 shrink-0 text-xs whitespace-nowrap lg:text-sm')}>
                     보호자 전화번호
                   </dt>
                   <dd className={cn('text-neutral-dark text-sm font-medium')}>

--- a/src/widgets/applicationSection/ui/ApplicationSection.tsx
+++ b/src/widgets/applicationSection/ui/ApplicationSection.tsx
@@ -90,20 +90,26 @@ const ApplicationSection = ({ user, application, activity }: ApplicationSectionP
             <div className={cn('grid grid-cols-1 gap-4 lg:grid-cols-2')}>
               <dl className={cn('flex flex-col gap-4')}>
                 <div className={cn('flex gap-4')}>
-                  <dt className={cn('text-secondary-slate w-14 shrink-0 text-xs lg:text-sm')}>이름</dt>
+                  <dt className={cn('text-secondary-slate w-14 shrink-0 text-xs lg:text-sm')}>
+                    이름
+                  </dt>
                   <dd className={cn('text-neutral-dark text-sm font-medium')}>
                     {application.name}
                   </dd>
                 </div>
                 <div className={cn('flex gap-4')}>
-                  <dt className={cn('text-secondary-slate w-14 shrink-0 text-xs lg:text-sm')}>학번</dt>
+                  <dt className={cn('text-secondary-slate w-14 shrink-0 text-xs lg:text-sm')}>
+                    학번
+                  </dt>
                   <dd className={cn('text-neutral-dark text-sm font-medium')}>
                     {application.grade}학년 {application.classNumber}반{' '}
                     {String(application.number).padStart(2, '0')}번
                   </dd>
                 </div>
                 <div className={cn('flex gap-4')}>
-                  <dt className={cn('text-secondary-slate w-14 shrink-0 text-xs lg:text-sm')}>학교명</dt>
+                  <dt className={cn('text-secondary-slate w-14 shrink-0 text-xs lg:text-sm')}>
+                    학교명
+                  </dt>
                   <dd className={cn('text-neutral-dark text-sm font-medium')}>
                     {application.schoolName}
                   </dd>
@@ -111,13 +117,23 @@ const ApplicationSection = ({ user, application, activity }: ApplicationSectionP
               </dl>
               <dl className={cn('flex flex-col gap-4')}>
                 <div className={cn('flex gap-4')}>
-                  <dt className={cn('text-secondary-slate w-24 shrink-0 text-xs whitespace-nowrap lg:text-sm')}>전화번호</dt>
+                  <dt
+                    className={cn(
+                      'text-secondary-slate w-24 shrink-0 text-xs whitespace-nowrap lg:text-sm',
+                    )}
+                  >
+                    전화번호
+                  </dt>
                   <dd className={cn('text-neutral-dark text-sm font-medium')}>
                     {application.phoneNumber}
                   </dd>
                 </div>
                 <div className={cn('flex gap-4')}>
-                  <dt className={cn('text-secondary-slate w-24 shrink-0 text-xs whitespace-nowrap lg:text-sm')}>
+                  <dt
+                    className={cn(
+                      'text-secondary-slate w-24 shrink-0 text-xs whitespace-nowrap lg:text-sm',
+                    )}
+                  >
                     보호자 전화번호
                   </dt>
                   <dd className={cn('text-neutral-dark text-sm font-medium')}>

--- a/src/widgets/applicationSection/ui/ApplicationSection.tsx
+++ b/src/widgets/applicationSection/ui/ApplicationSection.tsx
@@ -56,12 +56,14 @@ const ApplicationSection = ({ user, application, activity }: ApplicationSectionP
   return (
     <main
       className={cn(
-        'flex min-h-[calc(100vh-6.25rem-11.3125rem)] flex-col items-center bg-white px-4 py-12',
+        'flex flex-col items-center bg-white',
+        'min-h-111.25 px-6 py-12',
+        'lg:min-h-[calc(100vh-6.25rem-11.3125rem)] lg:px-4',
       )}
     >
       <div className={cn('flex w-full max-w-155.5 flex-col gap-9')}>
         {activity && (
-          <section className={cn('flex flex-col gap-4')}>
+          <section className={cn('flex flex-col gap-5 lg:gap-4')}>
             <SectionHeader
               title="신청한 학과 체험 정보"
               description="로그인된 계정으로 신청된 학과 체험을 확인할 수 있습니다."


### PR DESCRIPTION
## 개요

신청 조회 페이지(`/applications`)를 412 모바일 시안에 맞춰 반응형 대응했습니다.
헤더·푸터는 작업 범위에서 제외했습니다.

## 작업 내용

| 커밋 | 내용 |
| --- | --- |
| `fix: 학과 체험 카드가 모바일에서 고정 폭으로 넘치던 문제 수정` | `w-155.5`(622px) 고정 폭 → `w-full max-w-155.5` |
| `feat: 신청 조회 페이지 컨테이너 모바일 반응형 대응` | 좌우 여백 24px, 섹션 헤더-카드 간격 20px, 모바일 최소 높이 |
| `feat: 신청자 정보 카드 모바일 반응형 대응` | 2열 그리드 → 모바일 1열, 라벨 12px |
| `feat: 신청 조회 빈 상태 모바일 반응형 대응` | 제목 48px→24px, 설명 24px→14px, 좌우 여백·가운데 정렬 |

## 스크린샷
<img width="636" height="1052" alt="image" src="https://github.com/user-attachments/assets/94b46f0d-9410-4ce8-b318-5df32caf8c04" />

<img width="570" height="662" alt="image" src="https://github.com/user-attachments/assets/d248581e-0f88-4936-b98b-67d49e8001a8" />

## 참고 사항

- **`ProgramCard` 고정 폭 제거는 #115 의 `84ee3a3` 와 동일한 변경입니다.** 신청 조회 페이지 단독으로도 가로 넘침이 발생해 포함했으며, 내용이 완전히 동일해 어느 쪽이 먼저 머지되어도 충돌 없이 정리됩니다.
- 상위 컨테이너가 622px 고정인 학과 체험 신청 페이지·홈 프로그램 목록에서는 `ProgramCard` 렌더 결과가 기존과 동일합니다.
- 기존 최소 높이 계산식(`100vh - 100px - 181px`)은 데스크톱 헤더·푸터 기준이라 모바일 헤더(75px)·푸터 높이와 맞지 않습니다. 모바일에서는 시안상 본문 영역 높이인 445px(`min-h-111.25`)를 사용하고, `lg` 이상에서는 기존 계산식을 그대로 유지합니다.

## 확인

- `pnpm lint` 통과
- `pnpm build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)