### PR TITLE
[design] 자주 묻는 질문 페이지 412 모바일 반응형 대응

### DIFF
--- a/src/widgets/faqSection/ui/FaqItem.tsx
+++ b/src/widgets/faqSection/ui/FaqItem.tsx
@@ -51,7 +51,8 @@ const FaqItem = ({ item, index, isOpen, onToggle }: FaqItemProps) => (
           </span>
           <p
             className={cn(
-              'text-secondary-slate text-base leading-[1.6rem] font-normal tracking-[0.03rem] whitespace-pre-wrap',
+              'text-secondary-slate text-sm leading-[1.6] font-normal tracking-[0.03em] whitespace-pre-wrap',
+              'lg:text-base',
             )}
           >
             {item.answer}

--- a/src/widgets/faqSection/ui/FaqSection.tsx
+++ b/src/widgets/faqSection/ui/FaqSection.tsx
@@ -65,7 +65,8 @@ const FaqSection = () => {
   return (
     <main
       className={cn(
-        'flex min-h-[calc(100vh-6.25rem-11.3125rem)] flex-col items-center bg-white px-4 pt-9 pb-12',
+        'flex min-h-[calc(100vh-6.25rem-11.3125rem)] flex-col items-center bg-white px-6 pt-6 pb-12',
+        'lg:px-4 lg:pt-9',
       )}
     >
       <div className={cn('w-full max-w-150')}>


### PR DESCRIPTION
## 개요 💡

자주 묻는 질문 페이지를 412px 모바일 시안에 맞춰 반응형 대응했습니다.
헤더/푸터는 이번 작업 범위에서 제외했습니다.

[Figma - 자주 묻는 질문 (412, 기본)](https://www.figma.com/design/O2bHfV819OartFfRsq4IrN/Ready-GSM?node-id=3713-26414&m=dev)
[Figma - 자주 묻는 질문 (412, 펼침)](https://www.figma.com/design/O2bHfV819OartFfRsq4IrN/Ready-GSM?node-id=3713-26434&m=dev)

## 작업내용 ⌨️

시안과 실제 구현을 비교했을 때 차이가 있던 3곳만 `lg`(1024px) 기준으로 분기했습니다.
`lg` 이상 값은 기존과 동일하게 유지되어 데스크톱에는 변화가 없습니다.

| 항목 | 기존 | 모바일(< lg) | lg 이상 |
| --- | --- | --- | --- |
| 페이지 좌우 패딩 | 16px | **24px** | 16px (유지) |
| 페이지 상단 패딩 | 36px | **24px** | 36px (유지) |
| 답변 본문 폰트 | 16px | **14px** | 16px (유지) |

추가로 답변 본문의 `leading`/`tracking`을 rem 고정값에서 배수·em 단위로 바꿨습니다.

- `leading-[1.6rem]` → `leading-[1.6]`
- `tracking-[0.03rem]` → `tracking-[0.03em]`

16px 기준으로 계산하면 각각 25.6px / 0.48px로 기존과 완전히 동일한 값이라 데스크톱 렌더링은 그대로이고,
모바일 14px에서는 시안값인 22.4px / 0.42px이 됩니다.

## 스크린샷/동영상 📸

Chrome 412×915에서 실제 렌더링을 계측해 시안 수치와 일치하는 것을 확인했습니다.

| 계측 항목 | 시안 | 구현 |
| --- | --- | --- |
| 페이지 패딩 (상/우/하/좌) | 24 / 24 / 48 / 24 | 24 / 24 / 48 / 24 |
| 아이템 폭 | 364px | 364px |
| 아이템 패딩 | 20px 24px | 20px 24px |
| 제목 위치 · 크기 | left 24px · 24px | left 24px · 24px |
| 답변 폰트 / 행간 / 자간 | 14px / 1.6 / 0.42px | 14px / 22.4px / 0.42px |
| 답변 영역 패딩 | 10 / 24 / 20 / 24 | 10 / 24 / 20 / 24 |
| 펼침 테두리 | #4A80F8 | rgb(74, 128, 248) |

데스크톱(1440) 회귀 확인: 패딩 36/16/48/16, 답변 16px / 25.6px / 0.48px로 변경 전과 동일합니다.

## 리뷰 요청사항 👀

**1. 안내 문구**

시안에는 "자주 묻는 질문을 여기서 **검색하거나** 클릭하여 자세히 확인할 수 있습니다."로 되어 있지만,
시안에도 코드에도 검색 UI가 없어 현재 문구("자주 묻는 질문을 여기서 클릭하여 자세히 확인할 수 있습니다.")를 유지했습니다.
검색 기능이 예정되어 있다면 별도 이슈로 다루면 좋을 것 같습니다.

**2. 아이템 border-radius (기존 이슈)**

시안은 8px인데 현재 구현은 `rounded-lg`(10px)입니다.
모바일만 8px로 바꾸면 데스크톱과 값이 갈려서 이번 PR에서는 손대지 않았습니다.
데스크톱 시안도 8px이라면 `rounded-md`로 함께 정리하는 게 맞아 보입니다.

**3. 질문이 2줄로 넘어갈 때 정렬**

412px에서는 7개 중 5개 질문이 2줄로 줄바꿈되는데, 시안에는 한 줄짜리 질문만 있어 기준이 없습니다.
현재는 기존 구현대로 `Q.`와 화살표가 세로 가운데 정렬입니다. 위쪽 정렬이 나을지 의견 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
