### PR TITLE
[feat] 학과체험 예비인원 3명 제한 및 신청불가 상태 표시

### DIFF
--- a/src/entities/activity/index.ts
+++ b/src/entities/activity/index.ts
@@ -2,6 +2,7 @@ export { getActivityArchiveList } from './api/getActivityArchiveList';
 export { default as getActivityById } from './api/getActivityById';
 export { default as getActivityList } from './api/getActivityList';
 export { revalidateActivityList } from './api/revalidateActivityList';
+export { MAX_RESERVE_APPLICANT } from './model/constants';
 export type { ActivityListResponseType, ActivityType } from './model/types';
 export { default as useGetActivityById } from './model/useGetActivityById';
 export { activityQueryKeys, default as useGetActivityList } from './model/useGetActivityList';

--- a/src/entities/activity/model/constants.ts
+++ b/src/entities/activity/model/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_RESERVE_APPLICANT = 3;

--- a/src/entities/application/model/types.ts
+++ b/src/entities/application/model/types.ts
@@ -10,6 +10,7 @@ export interface ApplicationType {
   phoneNumber: string;
   familyPhoneNumber: string;
   isReserve: boolean;
+  reserveOrder: number | null;
 }
 
 export interface PostApplicationRequestType {

--- a/src/entities/program/ui/ProgramCard.tsx
+++ b/src/entities/program/ui/ProgramCard.tsx
@@ -1,12 +1,15 @@
 import type { ActivityType } from '@/entities/activity';
 import { cn } from '@/shared/lib';
 
+const MAX_RESERVE_APPLICANT = 3;
+
 interface ProgramCardProps extends Pick<
   ActivityType,
   'name' | 'description' | 'activityDate' | 'maxApplicant' | 'currentApplicant'
 > {
   isSelected?: boolean | undefined;
   isReserved?: boolean;
+  reserveOrder?: number | null;
   disableHover?: boolean;
   onClick?: () => void;
 }
@@ -19,24 +22,34 @@ const ProgramCard = ({
   currentApplicant,
   isSelected,
   isReserved,
+  reserveOrder,
   disableHover = false,
   onClick,
 }: ProgramCardProps) => {
-  const reservePersonnel = maxApplicant - currentApplicant;
-  const showReserveWarning = isReserved !== undefined ? isReserved : reservePersonnel <= 0;
+  const reserveApplicant = Math.max(currentApplicant - maxApplicant, 0);
+  const isReserveFull = reserveApplicant >= MAX_RESERVE_APPLICANT;
+  const isApplyDisabled = isReserved === undefined && isReserveFull;
+  const showReserveWarning =
+    isReserved !== undefined ? isReserved : currentApplicant >= maxApplicant;
+  const reserveBadgeText =
+    isReserved && reserveOrder != null ? `예비신청 ${reserveOrder}번` : '예비 신청';
 
   return (
     <section
       className={cn(
         'w-155.5 max-w-155.5 rounded-lg border bg-white px-6 py-5',
-        !disableHover && 'cursor-pointer transition-colors duration-200 hover:bg-[#EFF4FF]',
-        isSelected === true
-          ? 'border-[#2563EB]'
-          : isSelected === false
-            ? 'opacity-50'
-            : cn('border-border-variant', !disableHover && 'hover:border-[#7C91A9]'),
+        !disableHover &&
+          !isApplyDisabled &&
+          'cursor-pointer transition-colors duration-200 hover:bg-[#EFF4FF]',
+        isApplyDisabled
+          ? 'border-border-variant cursor-not-allowed opacity-50'
+          : isSelected === true
+            ? 'border-[#2563EB]'
+            : isSelected === false
+              ? 'opacity-50'
+              : cn('border-border-variant', !disableHover && 'hover:border-[#7C91A9]'),
       )}
-      onClick={onClick}
+      onClick={isApplyDisabled ? undefined : onClick}
     >
       <header className={cn('flex items-center justify-between')}>
         <h2
@@ -53,11 +66,19 @@ const ProgramCard = ({
             isSelected ? 'text-[#2563EB]' : 'text-neutral-dark',
           )}
         >
-          {showReserveWarning ? '예비 신청' : `${currentApplicant}/${maxApplicant}`}
+          {isApplyDisabled
+            ? '신청불가'
+            : showReserveWarning
+              ? reserveBadgeText
+              : `${currentApplicant}/${maxApplicant}`}
         </p>
       </header>
 
-      <p className={cn('text-secondary-slate mt-2 text-[0.875rem] leading-[1.4] font-normal')}>
+      <p
+        className={cn(
+          'text-secondary-slate mt-2 text-[0.875rem] leading-[1.4] font-normal whitespace-pre-line',
+        )}
+      >
         {description}
       </p>
 
@@ -65,10 +86,16 @@ const ProgramCard = ({
         {activityDate}
       </p>
 
-      {showReserveWarning && (
+      {isApplyDisabled ? (
         <p className={cn('text-error-red mt-2 text-[0.875rem] leading-[1.4] font-normal')}>
-          예비 신청의 경우, 신청이 확정되지 않으면 확정 안내 문자가 발송되지 않을 수 있습니다.
+          예비신청 정원 마감으로 신청이 불가합니다
         </p>
+      ) : (
+        showReserveWarning && (
+          <p className={cn('text-error-red mt-2 text-[0.875rem] leading-[1.4] font-normal')}>
+            예비 신청의 경우, 신청이 확정되지 않으면 확정 안내 문자가 발송되지 않을 수 있습니다.
+          </p>
+        )
       )}
     </section>
   );

--- a/src/entities/program/ui/ProgramCard.tsx
+++ b/src/entities/program/ui/ProgramCard.tsx
@@ -1,7 +1,5 @@
-import type { ActivityType } from '@/entities/activity';
+import { type ActivityType, MAX_RESERVE_APPLICANT } from '@/entities/activity';
 import { cn } from '@/shared/lib';
-
-const MAX_RESERVE_APPLICANT = 3;
 
 interface ProgramCardProps extends Pick<
   ActivityType,

--- a/src/features/applyDepartment/model/useApplicationForm.ts
+++ b/src/features/applyDepartment/model/useApplicationForm.ts
@@ -2,11 +2,13 @@ import { useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQueryClient } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
 
 import { activityQueryKeys, revalidateActivityList } from '@/entities/activity';
 import { usePostApplication } from '@/entities/application';
+import type { ApiResponseType } from '@/shared/api';
 
 import { ApplicationFormSchema, type ApplicationFormType } from './schema';
 
@@ -53,7 +55,15 @@ export const useApplicationForm = (activityId: number, userId: number, onSuccess
           toast.success('학과 체험 신청이 완료되었습니다.');
           onSuccess?.();
         },
-        onError: () => toast.error('신청 중 오류가 발생했습니다.'),
+        onError: async (error) => {
+          if (isAxiosError<ApiResponseType<null>>(error) && error.response?.status === 409) {
+            queryClient.invalidateQueries({ queryKey: activityQueryKeys.getActivityList() });
+            await revalidateActivityList();
+            toast.error(error.response.data.message);
+            return;
+          }
+          toast.error('신청 중 오류가 발생했습니다.');
+        },
       },
     );
   });

--- a/src/widgets/applicationSection/ui/ApplicationSection.tsx
+++ b/src/widgets/applicationSection/ui/ApplicationSection.tsx
@@ -73,6 +73,7 @@ const ApplicationSection = ({ user, application, activity }: ApplicationSectionP
               maxApplicant={activity.maxApplicant}
               currentApplicant={activity.currentApplicant}
               isReserved={application.isReserve}
+              reserveOrder={application.reserveOrder}
               disableHover
             />
           </section>


### PR DESCRIPTION
## 개요 💡

학과체험 예비 신청 인원을 최대 3명까지만 받도록 제한하고, 정원이 마감되면 신청이 불가능하도록 UI를 개선합니다. 서버 PR(readygsm-server#109)에서 예비인원 3명 제한 로직과 409 응답이 추가된 것에 대응하는 프론트엔드 작업입니다.

## 작업내용 ⌨️

- `ProgramCard`: 예비인원이 3명 찬 경우 "신청불가" 상태와 안내 문구를 표시하고 클릭을 비활성화 (카드 전체에 opacity 처리)
- `useApplicationForm`: 신청 시 서버 409(예비인원 마감) 응답을 감지해 서버 메시지를 그대로 토스트로 노출, 활동 목록 재검증
- `ApplicationType`에 `reserveOrder` 필드 추가, 신청 조회 화면에서 "예비신청 N번"으로 본인의 예비 순번 표시 (서버에서 `reserveOrder` 필드 추가 후 바로 동작)

## 스크린샷/동영상 📸

<img width="1406" height="1386" alt="image" src="https://github.com/user-attachments/assets/09336631-32da-4a03-82c7-89f3a102f918" />


## 관련 이슈 🚨

- Closes #118


## 리뷰 요청사항 👀

- `reserveOrder`는 서버 응답에 아직 없는 필드라 optional하게 처리했습니다. 서버에서 필드가 추가되면 별도 프론트 작업 없이 동작합니다.
