### PR TITLE
[design] 헤더·푸터·모달 412 모바일 반응형 대응

### DIFF
--- a/src/features/applyProgram/ui/DuplicatePhoneModal.tsx
+++ b/src/features/applyProgram/ui/DuplicatePhoneModal.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/shared/lib';
 import { Button, Modal } from '@/shared/ui';
 
 interface DuplicatePhoneModalProps {
@@ -6,7 +7,7 @@ interface DuplicatePhoneModalProps {
 }
 
 const DuplicatePhoneModal = ({ isOpen, onClose }: DuplicatePhoneModalProps) => (
-  <Modal isOpen={isOpen} onClose={onClose} className="w-120 px-6 py-5">
+  <Modal isOpen={isOpen} onClose={onClose} className={cn('w-full max-w-120 px-6 py-5')}>
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-2">
         <h2 className="text-neutral-dark text-2xl font-semibold">전화번호 중복</h2>

--- a/src/features/searchSchool/ui/SearchSchoolModal.tsx
+++ b/src/features/searchSchool/ui/SearchSchoolModal.tsx
@@ -1,5 +1,6 @@
 import { UseFormSetValue } from 'react-hook-form';
 
+import { cn } from '@/shared/lib';
 import { Button, Modal } from '@/shared/ui';
 
 import type { SchoolFormFieldsType, SchoolType } from '../model/types';
@@ -29,7 +30,7 @@ const SearchSchoolModal = ({ isOpen, onClose, setValue }: SearchSchoolModalProps
   } = useSearchSchool(handleSelectFormValues);
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} className="w-120 p-4">
+    <Modal isOpen={isOpen} onClose={onClose} className={cn('w-full max-w-120 p-4')}>
       <div className="flex flex-col gap-4">
         <h2 className="text-neutral-dark text-base leading-[1.4] font-medium">학교 찾기</h2>
         <SchoolSearchInput

--- a/src/shared/assets/Logo.tsx
+++ b/src/shared/assets/Logo.tsx
@@ -1,5 +1,16 @@
-const Logo = () => (
-  <svg width="44" height="42" viewBox="0 0 44 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+import { cn } from '@/shared/lib';
+
+interface LogoProps {
+  className?: string;
+}
+
+const Logo = ({ className }: LogoProps) => (
+  <svg
+    viewBox="0 0 44 42"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={cn('h-7 w-7.25 shrink-0', className)}
+  >
     <path
       d="M42.4545 21C46.4545 33.5 33.0525 42 21.4545 42C9.85653 42 -2.54553 31.5 0.454505 21C0.454505 9.40202 9.85653 0 21.4545 0C33.0525 0 42.4545 9.40202 42.4545 21Z"
       fill="var(--brand-accent)"

--- a/src/shared/ui/ConfirmModal.tsx
+++ b/src/shared/ui/ConfirmModal.tsx
@@ -32,7 +32,11 @@ const ConfirmModal = ({
   cancelVariant = 'outlineDanger',
   isPending = false,
 }: ConfirmModalProps) => (
-  <Modal isOpen={isOpen} onClose={isPending ? undefined : onClose} className="w-120 px-6 py-5">
+  <Modal
+    isOpen={isOpen}
+    onClose={isPending ? undefined : onClose}
+    className={cn('w-full max-w-120 px-6 py-5')}
+  >
     <div className={cn('flex flex-col gap-6')}>
       <div className={cn('flex flex-col gap-2')}>
         <h2 className={cn('text-neutral-dark text-2xl font-semibold')}>{title}</h2>

--- a/src/shared/ui/Modal.tsx
+++ b/src/shared/ui/Modal.tsx
@@ -24,7 +24,7 @@ const Modal = ({ isOpen, onClose, children, className }: ModalProps) => {
 
   return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className={cn('fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-6')}
       onClick={onClose}
     >
       <div

--- a/src/widgets/footer/ui/Footer.tsx
+++ b/src/widgets/footer/ui/Footer.tsx
@@ -13,7 +13,7 @@ const Footer = () => {
           'flex w-full flex-col items-start gap-3.25',
           'px-6 py-15',
           'lg:flex-row lg:items-center lg:justify-between lg:gap-2 lg:px-20 lg:py-5',
-          'min-[1440px]:max-w-360',
+          'xl:max-w-360',
         )}
       >
         <FooterGSMLogo />
@@ -25,8 +25,8 @@ const Footer = () => {
                 'text-neutral-slate text-right text-[1.125rem]/[1.6875rem] font-normal',
               )}
             >
-              ©{CURRENT_YEAR} Copyright 광주소프트웨어마이스터고등학교{' '}
-              <br className={cn('sm:hidden')} />
+              ©{CURRENT_YEAR} Copyright <br className={cn('lg:hidden')} />
+              광주소프트웨어마이스터고등학교 <br className={cn('lg:hidden')} />
               ALL RIGHTS RESERVED.
             </p>
 
@@ -48,9 +48,11 @@ const Footer = () => {
           <p className={cn('text-dark-utility text-right text-[0.875rem]/[1.25rem] font-normal')}>
             우) 62423 광주광역시 광산구 상무대로 312
             <br />
-            교무실 062)949-6800(08:30~16:30) 행정실 062)949-6806(08:30~16:30)
+            교무실 062)949-6800(08:30~16:30) <br className={cn('lg:hidden')} />
+            행정실 062)949-6806(08:30~16:30)
             <br />
-            팩스 062)941-7545 당직실 062)949-6899(평일야간, 휴일)
+            팩스 062)941-7545 <br className={cn('lg:hidden')} />
+            당직실 062)949-6899(평일야간, 휴일)
           </p>
         </div>
       </div>

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -85,7 +85,6 @@ const Header = () => {
               href={link.href}
               label={link.label}
               isActive={getIsActive(link.href)}
-              size="sm"
               withHover
             />
           ))}
@@ -127,8 +126,9 @@ const Header = () => {
           />
           <div
             className={cn(
-              'fixed top-18.75 right-0 bottom-0 z-40 overflow-y-auto bg-white lg:top-20 xl:hidden',
-              'inline-flex flex-col items-end pt-9 pr-6 pb-34.25 pl-12.75',
+              'fixed top-18.75 right-0 z-40 overflow-y-auto bg-white lg:top-20 xl:hidden',
+              'max-h-[calc(100dvh-4.6875rem)] lg:max-h-[calc(100dvh-5rem)]',
+              'inline-flex min-w-46.5 flex-col items-end pt-9 pr-6 pb-34.25',
             )}
           >
             <div className={cn('flex flex-col items-end gap-12')}>

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -65,7 +65,7 @@ const Header = () => {
         className={cn(
           'mx-auto flex max-w-480 items-center justify-between',
           'h-18.75 px-6',
-          'lg:h-25',
+          'lg:h-20 xl:h-16',
           isAdminRole && !isAdmin
             ? 'lg:px-12 xl:px-20 2xl:pr-[6.69rem] 2xl:pl-80'
             : 'lg:px-12 xl:px-20 2xl:px-80',
@@ -73,22 +73,25 @@ const Header = () => {
       >
         <Link href="/" className={cn('flex items-center gap-3')}>
           <Logo />
-          <span className={cn('text-neutral-dark text-[1.5rem] font-bold')}>Ready, GSM</span>
+          <span className={cn('text-neutral-dark text-2xl font-bold xl:text-base')}>
+            Ready, GSM
+          </span>
         </Link>
 
-        <nav className={cn('hidden items-center gap-12 lg:flex')}>
+        <nav className={cn('hidden items-center gap-12 xl:flex')}>
           {links.map((link) => (
             <NavLink
               key={link.href}
               href={link.href}
               label={link.label}
               isActive={getIsActive(link.href)}
+              size="sm"
               withHover
             />
           ))}
         </nav>
 
-        <div className={cn('hidden items-center gap-4 lg:flex')}>
+        <div className={cn('hidden items-center gap-4 xl:flex')}>
           {user ? (
             <Button onClick={handleSignOut} variant="outlinePrimary" size="md">
               로그아웃
@@ -107,7 +110,7 @@ const Header = () => {
 
         <button
           onClick={() => setMenuOpenPathname(isMenuOpen ? null : pathname)}
-          className={cn('flex items-center justify-center lg:hidden')}
+          className={cn('flex items-center justify-center xl:hidden')}
           aria-label={isMenuOpen ? '메뉴 닫기' : '메뉴 열기'}
         >
           {isMenuOpen ? <X size={32} /> : <HamburgerIcon />}
@@ -117,12 +120,14 @@ const Header = () => {
       {isMenuOpen && (
         <>
           <div
-            className={cn('fixed inset-x-0 top-18.75 bottom-0 z-40 bg-black/20 lg:hidden')}
+            className={cn(
+              'fixed inset-x-0 top-18.75 bottom-0 z-40 bg-black/20 lg:top-20 xl:hidden',
+            )}
             onClick={handleMenuClose}
           />
           <div
             className={cn(
-              'fixed top-18.75 right-0 bottom-0 z-40 overflow-y-auto bg-white lg:hidden',
+              'fixed top-18.75 right-0 bottom-0 z-40 overflow-y-auto bg-white lg:top-20 xl:hidden',
               'inline-flex flex-col items-end pt-9 pr-6 pb-34.25 pl-12.75',
             )}
           >

--- a/src/widgets/header/ui/NavLink.tsx
+++ b/src/widgets/header/ui/NavLink.tsx
@@ -2,27 +2,39 @@ import Link from 'next/link';
 
 import { cn } from '@/shared/lib';
 
+type NavLinkSizeType = 'sm' | 'lg';
+
 interface NavLinkProps {
   href: string;
   label: string;
   isActive: boolean;
   onClick?: () => void;
   withHover?: boolean;
+  size?: NavLinkSizeType;
 }
 
-const NavLink = ({ href, label, isActive, onClick, withHover = false }: NavLinkProps) => (
+const NavLink = ({
+  href,
+  label,
+  isActive,
+  onClick,
+  withHover = false,
+  size = 'lg',
+}: NavLinkProps) => (
   <Link
     href={href}
     onClick={onClick}
     className={cn(
-      'relative flex flex-col items-center text-2xl leading-[120%] font-semibold transition-colors',
+      'relative flex flex-col items-center leading-[120%] font-semibold transition-colors',
+      size === 'sm' ? 'text-base' : 'text-2xl',
       isActive ? 'text-neutral-dark' : cn('text-soft-gray', withHover && 'hover:text-dark-utility'),
     )}
   >
     {label}
     <span
       className={cn(
-        'bg-brand-primary absolute -bottom-2 h-1 rounded-lg transition-[width] duration-300 ease-in-out',
+        'bg-brand-primary absolute h-1 rounded-lg transition-[width] duration-300 ease-in-out',
+        size === 'sm' ? '-bottom-1' : '-bottom-2',
         isActive ? 'w-5' : 'w-0',
       )}
     />

--- a/src/widgets/header/ui/NavLink.tsx
+++ b/src/widgets/header/ui/NavLink.tsx
@@ -2,39 +2,27 @@ import Link from 'next/link';
 
 import { cn } from '@/shared/lib';
 
-type NavLinkSizeType = 'sm' | 'lg';
-
 interface NavLinkProps {
   href: string;
   label: string;
   isActive: boolean;
   onClick?: () => void;
   withHover?: boolean;
-  size?: NavLinkSizeType;
 }
 
-const NavLink = ({
-  href,
-  label,
-  isActive,
-  onClick,
-  withHover = false,
-  size = 'lg',
-}: NavLinkProps) => (
+const NavLink = ({ href, label, isActive, onClick, withHover = false }: NavLinkProps) => (
   <Link
     href={href}
     onClick={onClick}
     className={cn(
-      'relative flex flex-col items-center leading-[120%] font-semibold transition-colors',
-      size === 'sm' ? 'text-base' : 'text-2xl',
+      'relative flex flex-col items-center px-[0.21875rem] text-base leading-[120%] font-semibold whitespace-nowrap transition-colors',
       isActive ? 'text-neutral-dark' : cn('text-soft-gray', withHover && 'hover:text-dark-utility'),
     )}
   >
     {label}
     <span
       className={cn(
-        'bg-brand-primary absolute h-1 rounded-lg transition-[width] duration-300 ease-in-out',
-        size === 'sm' ? '-bottom-1' : '-bottom-2',
+        'bg-brand-primary absolute -bottom-1 h-1 rounded-lg transition-[width] duration-300 ease-in-out',
         isActive ? 'w-5' : 'w-0',
       )}
     />


### PR DESCRIPTION
## 개요 💡

전 페이지에서 공유하는 공용 셸(헤더, 푸터, 모달)의 412 모바일 반응형을 대응합니다.

페이지 단위 반응형(#115 학과 체험 신청, #116 신청 조회, #117 자주 묻는 질문)과 달리 특정 페이지에 속하지 않고 모든 페이지에 걸쳐 있는 공용 컴포넌트라 별도 브랜치로 분리했습니다. 특히 모달 3종은 수정 지점이 `shared/ui/Modal.tsx` 한 곳으로 수렴해서, 페이지별 브랜치로 쪼갤 경우 세 브랜치가 같은 파일을 건드리게 됩니다.

## 작업내용 ⌨️

### 헤더

- 1920/1440/1024/412 디자인에 맞춰 레이아웃 조정
- 햄버거 드로어 최소 너비 186px, 높이는 컨텐츠 기준으로 변경하고 뷰포트 초과 시 스크롤 유지
- 드로어 메뉴 텍스트 16px로 통일하고 `NavLink`의 `size` prop 제거

### 푸터

- 카피라이트를 모바일에서 3줄로, 주소·연락처를 5줄로 분리
- `max-width` 분기를 arbitrary px에서 `xl` 브레이크포인트로 변경

### 모달 (신규)

세 모달 모두 패딩·간격·타이포는 피그마 모바일 값이 데스크톱과 동일해서, 실제 차이는 **폭 하나**였습니다.

- `shared/ui/Modal.tsx` — 오버레이에 `px-6`(24px) 추가
- `ConfirmModal` / `DuplicatePhoneModal` / `SearchSchoolModal` — `w-120` 고정 폭을 `w-full max-w-120`으로 변경

이 조합으로 브레이크포인트 분기 없이 디자인 값이 그대로 나옵니다.

| 뷰포트 | 결과 |
| --- | --- |
| 412 | 412 − 24×2 = **364px** (피그마 값 일치) |
| 528 이상 | `max-w-120`(480px)에서 캡 → 기존 데스크톱 유지 |
| 중간 구간 | 유동적으로 채움 |

## 스크린샷/동영상 📸

<img width="576" height="936" alt="image" src="https://github.com/user-attachments/assets/0fcf111e-b316-48a9-a11a-f6c6720a251e" />

<img width="592" height="396" alt="image" src="https://github.com/user-attachments/assets/c7e1602c-19b4-4a52-a661-bfc36b545020" />

<img width="558" height="940" alt="image" src="https://github.com/user-attachments/assets/ad3408f7-05c6-4623-8846-025d2f3d293a" />

## 관련 이슈 🚨

- develop에 머지된 #119(예비인원 제한)를 병합했습니다. 변경 파일이 겹치지 않아 충돌은 없었습니다.
- 작업 중 확인한 사항인데, **`DuplicatePhoneModal`은 현재 어디에서도 호출되지 않습니다.** 컴포넌트와 배럴 export만 있고 사용처가 0건입니다. `useApplicationForm`의 409 분기는 #119에서 추가된 예비인원 초과용 토스트라 이 모달과는 연결되어 있지 않습니다. 이번 PR은 디자인 대응 범위라 로직은 건드리지 않았고, 별도 이슈로 분리하는 게 좋아 보입니다.

## 리뷰 요청사항 👀

세 가지 판단이 들어가 있어 확인 부탁드립니다.

1. **공용 컨테이너에 `w-full`을 넣지 않은 이유** — `LoginModal`은 폭 지정 없이 내용 기반(버튼 `w-75` + `p-6` = 348px)이라 공통에 `w-full`을 넣으면 데스크톱에서 480px로 늘어나 깨집니다. 그래서 오버레이 여백만 공통화하고 폭은 모달별로 뒀습니다.
2. **`max-h` / `overflow-y-auto`를 넣지 않은 이유** — 학교 찾기 모달의 결과 드롭다운이 `absolute`라 패널에 `overflow`를 걸면 잘립니다. 피그마에도 없는 스펙이라 제외했습니다.
3. **`ConfirmModal` 회귀 확인** — admin의 `DeleteActivityModal`, `DeleteUserModal`도 이 컴포넌트를 공유합니다. 데스크톱은 `max-w-120`으로 동일하게 유지되지만 한 번 봐주시면 좋겠습니다.
