### PR TITLE
style: 피그마 디자인 차이 수정

### DIFF
--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -22,11 +22,11 @@ const HomePage = async () => {
         className={cn(
           'bg-pure-white relative z-10 flex flex-col rounded-t-[1.5rem]',
           '-mt-86 gap-20 px-4 pt-4 pb-25',
-          'lg:-mt-91.75 lg:gap-60 lg:px-9 lg:pt-9.75 lg:pb-42.75',
-          'xl:-mt-45 xl:px-20 xl:pt-20',
+          'lg:-mt-91.75 lg:gap-60 lg:px-9 lg:pt-9.75 lg:pb-50',
+          'xl:-mt-45 xl:px-20 xl:pt-20 xl:pb-22.5',
         )}
       >
-        <div className={cn('flex flex-col gap-20')}>
+        <div className={cn('flex flex-col gap-20 lg:gap-30')}>
           <HomeSection2 />
           <HomeSection3 />
           <HomeSection4 />

--- a/src/widgets/footer/ui/Footer.tsx
+++ b/src/widgets/footer/ui/Footer.tsx
@@ -12,8 +12,8 @@ const Footer = () => {
         className={cn(
           'flex w-full flex-col items-start gap-3.25',
           'px-6 py-15',
-          'lg:flex-row lg:items-center lg:justify-between lg:gap-2 lg:px-20 lg:py-5',
-          'xl:max-w-360',
+          'lg:flex-row lg:items-center lg:justify-between lg:gap-2 lg:px-12',
+          'xl:max-w-360 xl:px-20',
         )}
       >
         <FooterGSMLogo />


### PR DESCRIPTION
## 변경 사항
- 메인 페이지의 섹션 하단 여백과 반응형 간격을 피그마 디자인에 맞게 조정했습니다.
- 푸터의 반응형 가로 여백을 메인 레이아웃과 맞췄습니다.

## 작업 범위
전체 모든 페이지를 탐색해 수정하는 작업은 범위가 커, 이번 PR에서는 우선 메인 페이지를 중심으로 확인·수정했습니다.

## 검증
- `pnpm format:check`
- `pnpm lint`

관련 이슈: themoment-team/readygsm-client#125